### PR TITLE
[SL-2432] feat: Add connect page with redirect, refactor object listing styling

### DIFF
--- a/src/components/betaReleaseAuthModal/betaReleaseAuthModal.component.tsx
+++ b/src/components/betaReleaseAuthModal/betaReleaseAuthModal.component.tsx
@@ -43,12 +43,20 @@ export const AddAuthTokenModal = ({
     const developmentUri = useDevelopmentDefaults ? SAAS_API_ENDPOINT : null;
     const developmentToken = useDevelopmentDefaults ? SAAS_API_KEY : null;
 
-    setInputUri(
-      localStorage.getItem(LOCAL_STORAGE.betaAuth.uri) || developmentUri,
-    );
-    setInputToken(
-      localStorage.getItem(LOCAL_STORAGE.betaAuth.token) || developmentToken,
-    );
+    const updateInputsFromLocalStorage = () => {
+      setInputUri(
+        localStorage.getItem(LOCAL_STORAGE.betaAuth.uri) || developmentUri,
+      );
+      setInputToken(
+        localStorage.getItem(LOCAL_STORAGE.betaAuth.token) || developmentToken,
+      );
+    };
+    updateInputsFromLocalStorage();
+
+    window.addEventListener("storage", updateInputsFromLocalStorage);
+    return () => {
+      window.removeEventListener("storage", updateInputsFromLocalStorage);
+    };
   }, []);
 
   useEffect(() => {

--- a/src/components/navigation/navigation/navigation.component.tsx
+++ b/src/components/navigation/navigation/navigation.component.tsx
@@ -24,7 +24,7 @@ export const Navigation = () => {
 
   return (
     <>
-      <div className="h-nav fixed top-0 left-0 right-0 z-40 flex flex-row items-center justify-start bg-nav-bar py-2 px-4 font-sans text-black md:flex-row md:justify-start lg:px-14">
+      <div className="h-nav fixed top-0 left-0 right-0 z-40 flex flex-row items-center justify-start bg-nav-bar py-2 px-4 font-sans text-black md:flex-row md:justify-start md:px-6 lg:px-10">
         <Link legacyBehavior href="/">
           <a className="z-50 flex items-center justify-start">
             <Image src={Logo} alt="Skylark Logo" width="30" height="30" />

--- a/src/components/objectListing/objectListing.component.tsx
+++ b/src/components/objectListing/objectListing.component.tsx
@@ -32,11 +32,7 @@ import { RowActions } from "./rowActions";
 import { Search } from "./search";
 import { Table, TableCell } from "./table";
 
-const hardcodedColumns = [
-  OBJECT_LIST_TABLE.columnIds.objectType,
-  "availability",
-  "images",
-];
+const hardcodedColumns = ["availability", "images"];
 const orderedKeys = ["uid", "external_id", "data_source_id"];
 
 const columnHelper = createColumnHelper<object>();

--- a/src/components/objectListing/table/table.component.tsx
+++ b/src/components/objectListing/table/table.component.tsx
@@ -57,7 +57,7 @@ const customColumnStyling: Record<
   [OBJECT_LIST_TABLE.columnIds.objectType]: {
     width: "min-w-24 max-w-24",
     className: {
-      all: "px-0 pr-1 md:pr-1.5 md:bg-white md:sticky md:-left-18",
+      all: "px-0 pr-1 md:pr-1.5 md:bg-white md:sticky",
       cell: "sticky -left-20",
       withCheckbox: "-left-14 md:-left-12",
     },

--- a/src/components/objectListing/table/table.component.tsx
+++ b/src/components/objectListing/table/table.component.tsx
@@ -48,7 +48,7 @@ const customColumnStyling: Record<
   [OBJECT_LIST_TABLE.columnIds.displayField]: {
     width: "min-w-56 max-w-56",
     className: {
-      all: "md:sticky bg-white z-10 pl-0 [&>span]:pl-0 [&>span]:border-l-0 border-l-0 pr-0 shadow-[6px_0px_8px_0px_rgba(0,0,0,0.39)]",
+      all: "md:sticky bg-white z-10 pl-0 [&>span]:pl-0 [&>span]:border-l-0 border-l-0 pr-0",
       cell: "left-5",
       header: "left-0",
       withCheckbox: "left-10",

--- a/src/components/objectListing/table/table.component.tsx
+++ b/src/components/objectListing/table/table.component.tsx
@@ -49,21 +49,21 @@ const customColumnStyling: Record<
     width: "min-w-56 max-w-56",
     className: {
       all: "md:sticky bg-white z-10 pl-0 [&>span]:pl-0 [&>span]:border-l-0 border-l-0 pr-0",
-      cell: "left-5",
-      header: "left-0",
+      cell: "left-3.5",
+      header: "-left-px",
       withCheckbox: "left-10",
     },
   },
   [OBJECT_LIST_TABLE.columnIds.objectType]: {
     width: "min-w-24 max-w-24",
     className: {
-      all: "px-0 pr-1 md:pr-3 md:bg-white md:sticky md:-left-18",
+      all: "px-0 pr-1 md:pr-1.5 md:bg-white md:sticky md:-left-18",
       cell: "sticky -left-20",
       withCheckbox: "-left-14 md:-left-12",
     },
   },
   [OBJECT_LIST_TABLE.columnIds.checkbox]: {
-    width: "min-w-7 max-w-7 md:min-w-7 md:max-w-7",
+    width: "min-w-7 max-w-7",
     className: {
       all: "pr-2 pl-0 sticky -left-px bg-white z-20",
     },

--- a/src/components/objectListing/table/table.component.tsx
+++ b/src/components/objectListing/table/table.component.tsx
@@ -46,21 +46,27 @@ const customColumnStyling: Record<
     className: { all: "pr-1" },
   },
   [OBJECT_LIST_TABLE.columnIds.displayField]: {
-    width: "min-w-52 max-w-52",
+    width: "min-w-56 max-w-56",
     className: {
-      all: "md:sticky -left-px bg-white z-10 pl-0 [&>span]:pl-0 [&>span]:border-l-0 border-l-0 pr-0",
-      withCheckbox: "left-7",
+      all: "md:sticky bg-white z-10 pl-0 [&>span]:pl-0 [&>span]:border-l-0 border-l-0 pr-0 shadow-[6px_0px_8px_0px_rgba(0,0,0,0.39)]",
+      cell: "left-5",
+      header: "left-0",
+      withCheckbox: "left-10",
     },
   },
   [OBJECT_LIST_TABLE.columnIds.objectType]: {
     width: "min-w-24 max-w-24",
     className: {
-      all: "px-0 pr-3",
+      all: "px-0 pr-1 md:pr-3 md:bg-white md:sticky md:-left-18",
+      cell: "sticky -left-20",
+      withCheckbox: "-left-14 md:-left-12",
     },
   },
   [OBJECT_LIST_TABLE.columnIds.checkbox]: {
-    width: "min-w-8 max-w-8",
-    className: { all: "pr-4 pl-0 sticky -left-px bg-white" },
+    width: "min-w-7 max-w-7 md:min-w-7 md:max-w-7",
+    className: {
+      all: "pr-2 pl-0 sticky -left-px bg-white z-20",
+    },
   },
   images: {
     width: "min-w-24 max-w-24",

--- a/src/components/objectListing/table/table.component.tsx
+++ b/src/components/objectListing/table/table.component.tsx
@@ -50,15 +50,14 @@ const customColumnStyling: Record<
     className: {
       all: "md:sticky bg-white z-10 pl-0 [&>span]:pl-0 [&>span]:border-l-0 border-l-0 pr-0",
       cell: "left-3.5",
-      header: "-left-px",
+      header: "left-3.5",
       withCheckbox: "left-10",
     },
   },
   [OBJECT_LIST_TABLE.columnIds.objectType]: {
     width: "min-w-24 max-w-24",
     className: {
-      all: "px-0 pr-1 md:pr-1.5 md:bg-white md:sticky",
-      cell: "sticky -left-20",
+      all: "px-0 pr-1 md:pr-1.5 md:bg-white sticky -left-20",
       withCheckbox: "-left-14 md:-left-12",
     },
   },

--- a/src/components/panel/panel.test.tsx
+++ b/src/components/panel/panel.test.tsx
@@ -128,10 +128,11 @@ test("renders the objects primaryField and colour in the header when given", asy
       mockWithRandomPrimaryField.result.data.getObject.release_date,
     ),
   ).toBeInTheDocument();
+
   expect(
-    panelHeader.getByText(
-      mockWithRandomPrimaryField.result.data.getObject.__typename,
-    ),
+    panelHeader
+      .getByText(mockWithRandomPrimaryField.result.data.getObject.__typename)
+      .closest("div"),
   ).toHaveAttribute("style", "background-color: rgb(123, 123, 123);");
 });
 

--- a/src/components/pill/pill.component.tsx
+++ b/src/components/pill/pill.component.tsx
@@ -7,11 +7,11 @@ export interface PillProps {
 }
 
 export const Pill = ({ label, bgColor, className }: PillProps) => (
-  <span
+  <div
     // TODO determine text colour based on background
     className={clsx(`badge border-none px-3 text-xs text-white`, className)}
     style={bgColor ? { backgroundColor: bgColor } : undefined}
   >
-    {label}
-  </span>
+    <span className="overflow-hidden text-clip">{label}</span>
+  </div>
 );

--- a/src/constants/skylark.ts
+++ b/src/constants/skylark.ts
@@ -9,7 +9,7 @@ export const REQUEST_HEADERS = {
 };
 export const OBJECT_LIST_TABLE = {
   columnIds: {
-    objectType: "object type",
+    objectType: "__typename",
     displayField: "skylark-ui-display-field",
     checkbox: "skylark-ui-select",
     actions: "skylark-ui-actions",

--- a/src/constants/skylark.ts
+++ b/src/constants/skylark.ts
@@ -9,7 +9,7 @@ export const REQUEST_HEADERS = {
 };
 export const OBJECT_LIST_TABLE = {
   columnIds: {
-    objectType: "__typename", // This is the built-in GraphQL __typename
+    objectType: "object type",
     displayField: "skylark-ui-display-field",
     checkbox: "skylark-ui-select",
     actions: "skylark-ui-actions",

--- a/src/pages/beta/connect.tsx
+++ b/src/pages/beta/connect.tsx
@@ -2,11 +2,9 @@ import { useRouter } from "next/router";
 import { useEffect } from "react";
 
 import { LOCAL_STORAGE } from "src/constants/skylark";
-import { useConnectedToSkylark } from "src/hooks/useConnectedToSkylark";
 
 export default function BetaConnect() {
   const { query, push: navigateTo } = useRouter();
-  // const { connected } = useConnectedToSkylark();
 
   useEffect(() => {
     if (query.uri && query.apikey) {
@@ -21,8 +19,6 @@ export default function BetaConnect() {
     }
   }, [query, navigateTo]);
 
-  console.log({ query });
-
   return (
     <div className="flex h-screen w-screen flex-col items-center justify-center gap-4">
       <h1 className="mb-4 font-heading text-3xl">Skylark Auto Connect</h1>
@@ -32,7 +28,7 @@ export default function BetaConnect() {
             Enter your Skylark URI and API Key into the URL to auto connect.
           </p>
           <p>
-            {"Format: "}{" "}
+            {"Format: "}
             <code>
               {"?uri=${skylark_graphql_url}&apikey=${skylark_api_key}"}
             </code>

--- a/src/pages/beta/connect.tsx
+++ b/src/pages/beta/connect.tsx
@@ -1,0 +1,49 @@
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+import { LOCAL_STORAGE } from "src/constants/skylark";
+import { useConnectedToSkylark } from "src/hooks/useConnectedToSkylark";
+
+export default function BetaConnect() {
+  const { query, push: navigateTo } = useRouter();
+  // const { connected } = useConnectedToSkylark();
+
+  useEffect(() => {
+    if (query.uri && query.apikey) {
+      localStorage.setItem(LOCAL_STORAGE.betaAuth.uri, query.uri as string);
+      localStorage.setItem(
+        LOCAL_STORAGE.betaAuth.token,
+        query.apikey as string,
+      );
+      // storage events are not picked up in the same tab, so dispatch it for the current one
+      window.dispatchEvent(new Event("storage"));
+      navigateTo("/");
+    }
+  }, [query, navigateTo]);
+
+  console.log({ query });
+
+  return (
+    <div className="flex h-screen w-screen flex-col items-center justify-center gap-4">
+      <h1 className="mb-4 font-heading text-3xl">Skylark Auto Connect</h1>
+      {!query.uri || !query.apikey ? (
+        <>
+          <p>
+            Enter your Skylark URI and API Key into the URL to auto connect.
+          </p>
+          <p>
+            {"Format: "}{" "}
+            <code>
+              {"?uri=${skylark_graphql_url}&apikey=${skylark_api_key}"}
+            </code>
+          </p>
+        </>
+      ) : (
+        <>
+          <p>URI and API Key found in URL.</p>
+          <p>Adding to Local Storage and redirecting to Content Library.</p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import { ObjectList } from "src/components/objectListing";
 
 export default function Home() {
   return (
-    <div className="px-4 pt-20 md:px-14 md:pt-28">
+    <div className="px-2 pt-18 sm:px-4 md:px-6 md:pt-28 lg:px-10">
       <ObjectList withCreateButtons />
     </div>
   );

--- a/src/tests/pages/beta/connect.test.tsx
+++ b/src/tests/pages/beta/connect.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+
+import { LOCAL_STORAGE } from "src/constants/skylark";
+import ConnectPage from "src/pages/beta/connect";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const useRouter = jest.spyOn(require("next/router"), "useRouter");
+
+test("displays help text when URI or API Key not given", () => {
+  const router = { push: jest.fn(), query: { uri: "sfsdf" } };
+  useRouter.mockReturnValue(router);
+
+  render(<ConnectPage />);
+
+  expect(
+    screen.getByText(
+      "Enter your Skylark URI and API Key into the URL to auto connect.",
+    ),
+  ).toBeInTheDocument();
+  expect(router.push).not.toHaveBeenCalled();
+});
+
+test("updates localStorage when URI and API key are given", () => {
+  const uri = "skylark.com/graphql";
+  const apikey = "da2-asfsdf";
+  const router = { push: jest.fn(), query: { uri, apikey } };
+  useRouter.mockReturnValue(router);
+  Storage.prototype.setItem = jest.fn();
+
+  render(<ConnectPage />);
+
+  expect(screen.getByText("URI and API Key found in URL.")).toBeInTheDocument();
+  expect(localStorage.setItem).toHaveBeenCalledTimes(2);
+  expect(localStorage.setItem).toHaveBeenCalledWith(
+    LOCAL_STORAGE.betaAuth.uri,
+    uri,
+  );
+  expect(localStorage.setItem).toHaveBeenCalledWith(
+    LOCAL_STORAGE.betaAuth.token,
+    apikey,
+  );
+  expect(router.push).toHaveBeenCalledWith("/");
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -46,6 +46,9 @@ module.exports = {
       animation: {
         "spin-fast": "spin 0.5s linear infinite",
       },
+      spacing: {
+        18: "4.5rem",
+      },
       minWidth: (theme) => ({
         ...theme("spacing"),
       }),


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->
- Adds `/beta/connect` page to connect to a customer environment easily (saves copying and pasting environment info)
- Changes the `__typename` in Filters to `object type`
- Refactors object listing styling to:
  - Span more of home page
  - Show the end of a Pill when stickied so that its easier to identify the object type

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Feature

https://skylarkplatform.atlassian.net/browse/SL-2432


