### PR TITLE
feat: Pagination of Flatfile data

### DIFF
--- a/cypress/downloads/Episode_example.csv
+++ b/cypress/downloads/Episode_example.csv
@@ -1,4 +1,0 @@
-external_id,slug,episode_number,release_date,synopsis_long,synopsis_medium,synopsis_short,title,title_long,title_medium,title_short
-example,example,10,2023-03-07+00:00,example,example,example,example,example,example,example
-,,-5,2011-02-02+00:00,,,,,,,
-,,,,,,,,,,

--- a/src/__tests__/fixtures/skylark/apiRoutes/importEpisodes.json
+++ b/src/__tests__/fixtures/skylark/apiRoutes/importEpisodes.json
@@ -1,97 +1,100 @@
-[
-  {
-    "id": 1,
-    "status": "accepted",
-    "valid": true,
-    "data": {
-      "episode_number": 1,
-      "external_id": null,
-      "release_date": null,
-      "slug": "episode-1",
-      "synopsis_long": null,
-      "synopsis_medium": null,
-      "synopsis_short": null,
-      "title": "Episode1",
-      "title_long": "Episode 1: The Original",
-      "title_medium": null,
-      "title_short": "Episode 1"
+{
+  "totalRows": 5,
+  "rows": [
+    {
+      "id": 1,
+      "status": "accepted",
+      "valid": true,
+      "data": {
+        "episode_number": 1,
+        "external_id": null,
+        "release_date": null,
+        "slug": "episode-1",
+        "synopsis_long": null,
+        "synopsis_medium": null,
+        "synopsis_short": null,
+        "title": "Episode1",
+        "title_long": "Episode 1: The Original",
+        "title_medium": null,
+        "title_short": "Episode 1"
+      },
+      "info": []
     },
-    "info": []
-  },
-  {
-    "id": 2,
-    "status": "accepted",
-    "valid": true,
-    "data": {
-      "episode_number": 2,
-      "external_id": null,
-      "release_date": null,
-      "slug": "episode-2",
-      "synopsis_long": null,
-      "synopsis_medium": null,
-      "synopsis_short": null,
-      "title": "Episode2",
-      "title_long": "Episode 2: Back Again",
-      "title_medium": null,
-      "title_short": "Episode 2"
+    {
+      "id": 2,
+      "status": "accepted",
+      "valid": true,
+      "data": {
+        "episode_number": 2,
+        "external_id": null,
+        "release_date": null,
+        "slug": "episode-2",
+        "synopsis_long": null,
+        "synopsis_medium": null,
+        "synopsis_short": null,
+        "title": "Episode2",
+        "title_long": "Episode 2: Back Again",
+        "title_medium": null,
+        "title_short": "Episode 2"
+      },
+      "info": []
     },
-    "info": []
-  },
-  {
-    "id": 3,
-    "status": "accepted",
-    "valid": true,
-    "data": {
-      "episode_number": 3,
-      "external_id": null,
-      "release_date": null,
-      "slug": "episode-3",
-      "synopsis_long": null,
-      "synopsis_medium": null,
-      "synopsis_short": null,
-      "title": "Episode3",
-      "title_long": "Episode 3: Three's a crowd",
-      "title_medium": null,
-      "title_short": "Episode 3"
+    {
+      "id": 3,
+      "status": "accepted",
+      "valid": true,
+      "data": {
+        "episode_number": 3,
+        "external_id": null,
+        "release_date": null,
+        "slug": "episode-3",
+        "synopsis_long": null,
+        "synopsis_medium": null,
+        "synopsis_short": null,
+        "title": "Episode3",
+        "title_long": "Episode 3: Three's a crowd",
+        "title_medium": null,
+        "title_short": "Episode 3"
+      },
+      "info": []
     },
-    "info": []
-  },
-  {
-    "id": 4,
-    "status": "accepted",
-    "valid": true,
-    "data": {
-      "episode_number": 4,
-      "external_id": null,
-      "release_date": null,
-      "slug": "episode-4",
-      "synopsis_long": null,
-      "synopsis_medium": null,
-      "synopsis_short": null,
-      "title": "Episode4",
-      "title_long": "Episode 4: Penultimate",
-      "title_medium": null,
-      "title_short": "Episode 4"
+    {
+      "id": 4,
+      "status": "accepted",
+      "valid": true,
+      "data": {
+        "episode_number": 4,
+        "external_id": null,
+        "release_date": null,
+        "slug": "episode-4",
+        "synopsis_long": null,
+        "synopsis_medium": null,
+        "synopsis_short": null,
+        "title": "Episode4",
+        "title_long": "Episode 4: Penultimate",
+        "title_medium": null,
+        "title_short": "Episode 4"
+      },
+      "info": []
     },
-    "info": []
-  },
-  {
-    "id": 5,
-    "status": "accepted",
-    "valid": true,
-    "data": {
-      "episode_number": 5,
-      "external_id": null,
-      "release_date": null,
-      "slug": "episode-5",
-      "synopsis_long": null,
-      "synopsis_medium": null,
-      "synopsis_short": null,
-      "title": "Episode5",
-      "title_long": "Episode 5: Cease to exist",
-      "title_medium": null,
-      "title_short": "Episode 5"
-    },
-    "info": []
-  }
-]
+    {
+      "id": 5,
+      "status": "accepted",
+      "valid": true,
+      "data": {
+        "episode_number": 5,
+        "external_id": null,
+        "release_date": null,
+        "slug": "episode-5",
+        "synopsis_long": null,
+        "synopsis_medium": null,
+        "synopsis_short": null,
+        "title": "Episode5",
+        "title_long": "Episode 5: Cease to exist",
+        "title_medium": null,
+        "title_short": "Episode 5"
+      },
+      "info": []
+    }
+  ]
+}

--- a/src/__tests__/fixtures/skylark/mutations/import/csvImportEpisodeCreationErrored.json
+++ b/src/__tests__/fixtures/skylark/mutations/import/csvImportEpisodeCreationErrored.json
@@ -1,0 +1,27 @@
+{
+  "data": {
+    "createEpisode_bf553d58_816d_4a1b_a3c9_ff34dc2bdbee_1": {
+      "uid": "01GTYFH4X75A60MEKQKQ8NJRV1",
+      "external_id": "string1"
+    },
+    "createEpisode_bf553d58_816d_4a1b_a3c9_ff34dc2bdbee_2": {
+      "uid": "01GTYFH50JAP4NRE693YQA4WRW",
+      "external_id": "string2"
+    },
+    "createEpisode_bf553d58_816d_4a1b_a3c9_ff34dc2bdbee_3": null,
+    "createEpisode_bf553d58_816d_4a1b_a3c9_ff34dc2bdbee_4": {
+      "uid": "01GTYFH53GZWEBEG9TSD0TF5KK",
+      "external_id": null
+    }
+  },
+  "errors": [
+    {
+      "path": ["createEpisode_bf553d58_816d_4a1b_a3c9_ff34dc2bdbee_3"],
+      "data": null,
+      "errorType": "ExternalIDException",
+      "errorInfo": null,
+      "locations": [{ "line": 10, "column": 5, "sourceName": null }],
+      "message": "External ID string3 already exists"
+    }
+  ]
+}

--- a/src/__tests__/mocks/handlers/flatfile.ts
+++ b/src/__tests__/mocks/handlers/flatfile.ts
@@ -45,6 +45,25 @@ export const mockFlatfileGetFinalDatabaseView: FlatfileGetFinalDatabaseViewRespo
     },
   };
 
+export const mockFlatfileGetFinalDatabaseViewPaginated: FlatfileGetFinalDatabaseViewResponse =
+  {
+    getFinalDatabaseView: {
+      totalRows: rows.length,
+      rows: [
+        {
+          ...rows[0],
+          id: 100,
+          data: { title: "paginated 1" },
+        },
+        {
+          ...rows[1],
+          id: 101,
+          data: { title: "paginated 2" },
+        },
+      ],
+    },
+  };
+
 export const erroredFlatfileAccessKeyExchangeHandler = rest.post(
   "https://api.us.flatfile.io/auth/access-key/exchange/",
   (req, res, ctx) => {
@@ -84,9 +103,15 @@ export const flatfileHandlers = [
     },
   ),
 
-  graphql.query("GET_FINAL_DATABASE_VIEW", (req, res, ctx) => {
-    return res(ctx.data(mockFlatfileGetFinalDatabaseView));
-  }),
+  graphql.query(
+    "GET_FINAL_DATABASE_VIEW",
+    ({ variables: { offset } }, res, ctx) => {
+      if (offset) {
+        return res(ctx.data(mockFlatfileGetFinalDatabaseViewPaginated));
+      }
+      return res(ctx.data(mockFlatfileGetFinalDatabaseView));
+    },
+  ),
 
   graphql.query("GET_TEMPLATES", (req, res, ctx) => {
     const data: FlatfileGetTemplatesResponse = {

--- a/src/__tests__/mocks/handlers/flatfile.ts
+++ b/src/__tests__/mocks/handlers/flatfile.ts
@@ -31,8 +31,8 @@ const rows: FlatfileRow[] = [
   },
   {
     id: 2,
-    status: "invalid",
-    valid: false, // This one will be filtered out, if it breaks the GraphQL mutation below will fail
+    status: "accepted",
+    valid: true,
     data: { title: "episode 2" },
   },
 ];
@@ -40,6 +40,7 @@ const rows: FlatfileRow[] = [
 export const mockFlatfileGetFinalDatabaseView: FlatfileGetFinalDatabaseViewResponse =
   {
     getFinalDatabaseView: {
+      totalRows: rows.length,
       rows,
     },
   };

--- a/src/interfaces/apiRoutes.ts
+++ b/src/interfaces/apiRoutes.ts
@@ -1,4 +1,16 @@
+import { FlatfileRow } from "./flatfile/responses";
+
 export interface ApiRouteTemplateData {
   embedId: string;
   token: string;
+}
+export interface ApiRouteFlatfileImportRequestBody {
+  batchId: string;
+  limit: number;
+  offset?: number;
+}
+
+export interface ApiRouteFlatfileImportResponse {
+  rows: FlatfileRow[];
+  totalRows: number;
 }

--- a/src/interfaces/flatfile/responses.ts
+++ b/src/interfaces/flatfile/responses.ts
@@ -57,6 +57,7 @@ export interface FlatfileRow {
 export interface FlatfileGetFinalDatabaseViewResponse {
   getFinalDatabaseView: {
     rows: FlatfileRow[];
+    totalRows: number;
   };
 }
 

--- a/src/lib/flatfile/api/databaseView.ts
+++ b/src/lib/flatfile/api/databaseView.ts
@@ -5,11 +5,15 @@ import { GET_FINAL_DATABASE_VIEW } from "src/lib/graphql/flatfile/queries";
 export const getFlatfileFinalDatabaseView = async (
   client: FlatfileClient,
   batchId: string,
+  limit = 1000,
+  offset = 0,
 ) => {
   const data = await client.request<FlatfileGetFinalDatabaseViewResponse>(
     GET_FINAL_DATABASE_VIEW,
     {
       batchId,
+      limit,
+      offset,
     },
   );
 

--- a/src/lib/flatfile/import.ts
+++ b/src/lib/flatfile/import.ts
@@ -221,7 +221,7 @@ export const createFlatfileObjectsInSkylark = async (
               err as GQLSkylarkErrorResponse<FlatfileObjectsCreatedInSkylarkFields>;
             return {
               errors: response.errors,
-              data: [],
+              data: response.data ? Object.values(response.data) : [],
             };
           }
           return {

--- a/src/lib/graphql/flatfile/queries.ts
+++ b/src/lib/graphql/flatfile/queries.ts
@@ -39,8 +39,18 @@ export const GET_TEMPLATES = gql`
 `;
 
 export const GET_FINAL_DATABASE_VIEW = gql`
-  query GET_FINAL_DATABASE_VIEW($batchId: UUID!) {
-    getFinalDatabaseView(batchId: $batchId, limit: 1000000) {
+  query GET_FINAL_DATABASE_VIEW(
+    $batchId: UUID!
+    $limit: Int!
+    $offset: Int = 0
+  ) {
+    getFinalDatabaseView(
+      status: "accepted"
+      batchId: $batchId
+      limit: $limit
+      skip: $offset
+    ) {
+      totalRows
       rows
     }
   }

--- a/src/pages/import/csv.tsx
+++ b/src/pages/import/csv.tsx
@@ -121,7 +121,7 @@ const copyText: {
       success:
         "{numCreated} {objectType} objects have been successfully imported into Skylark",
       error:
-        "Error creating {numErrored} {objectType} objects ({numCreated} created). Check the console or try again.",
+        "Error creating {numErrored} {objectType} objects ({numCreated}/{totalImportedToFlatfile} created). Check the console or try again.",
     },
   },
 };
@@ -154,7 +154,11 @@ export default function CSVImportPage() {
   const { objectOperations } = useSkylarkObjectOperations(objectType);
 
   const [state, dispatch] = useReducer(reducer, initialState);
-  const [{ numCreated, numErrored }, setObjectAmounts] = useState({
+  const [
+    { numCreated, numErrored, totalImportedToFlatfile },
+    setObjectAmounts,
+  ] = useState({
+    totalImportedToFlatfile: 0,
     numCreated: 0,
     numErrored: 0,
   });
@@ -212,6 +216,7 @@ export default function CSVImportPage() {
       );
 
       setObjectAmounts({
+        totalImportedToFlatfile: numObjectsToCreate,
         numCreated: skylarkObjects.data.length,
         numErrored: skylarkObjects.errors.length,
       });
@@ -224,6 +229,7 @@ export default function CSVImportPage() {
     } catch (err) {
       console.error(err);
       setObjectAmounts({
+        totalImportedToFlatfile: numObjectsToCreate,
         numCreated: 0,
         numErrored: numObjectsToCreate,
       });
@@ -341,6 +347,10 @@ export default function CSVImportPage() {
                 title={copyCard.title}
                 description={copyCard.messages[status]
                   .replace("{objectType}", objectType)
+                  .replace(
+                    "{totalImportedToFlatfile}",
+                    totalImportedToFlatfile.toString(),
+                  )
                   .replace("{numCreated}", numCreated.toString())
                   .replace("{numErrored}", numErrored.toString())}
                 status={status}


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->
If imported data to Flatfile is more than 1000 rows then it will paginate the calls to the API route to get the data. This stops timeouts in API routes.

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Bugfix

#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://skylarkplatform.atlassian.net/browse/SL-2546

