### PR TITLE
[SL-2598,SL-2462,SL-2587,SL-2501] Content library bug fixes

### DIFF
--- a/src/components/contentLibrary/contentLibrary.component.tsx
+++ b/src/components/contentLibrary/contentLibrary.component.tsx
@@ -9,7 +9,7 @@ import {
   DragStartEvent,
 } from "@dnd-kit/core";
 import clsx from "clsx";
-import { m, useMotionValue } from "framer-motion";
+import { m, useMotionValue, useTransform } from "framer-motion";
 import React, { useEffect, useState, useRef, useCallback } from "react";
 
 import { ObjectIdentifierCard } from "src/components/objectIdentifierCard";
@@ -17,6 +17,12 @@ import { ObjectList } from "src/components/objectListing";
 import { Panel } from "src/components/panel";
 import { DROPPABLE_ID } from "src/constants/skylark";
 import { ParsedSkylarkObject } from "src/interfaces/skylark";
+
+const INITIAL_PANEL_PERCENTAGE = 80;
+const MINIMUM_SIZES = {
+  objectListing: 425,
+  panel: 450,
+};
 
 export const ContentLibrary = () => {
   const [activePanelObject, setActivePanelObject] = useState<{
@@ -34,40 +40,63 @@ export const ContentLibrary = () => {
   const mousePosition = useRef(0);
 
   const objectListingWidth = useMotionValue<number | undefined>(undefined);
-  const objectListingRef = useRef<HTMLInputElement | null>(null);
+  const panelWidth = useTransform(objectListingWidth, (width) =>
+    width === undefined ? undefined : windowSize - width,
+  );
+  const lastPanelWidth = useMotionValue<number | undefined>(undefined);
+  const containerRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const updateWindowSize = () => {
-      setWindowSize(window.innerWidth);
-      if (!activePanelObject) objectListingWidth.set(undefined);
-    };
-    updateWindowSize();
-
-    window.addEventListener("resize", updateWindowSize);
-    return () => {
-      window.removeEventListener("resize", updateWindowSize);
-    };
-  }, [activePanelObject, objectListingWidth]);
+  const closePanel = () => {
+    lastPanelWidth.set(panelWidth.get());
+    setActivePanelObject(null);
+  };
 
   useEffect(() => {
     const handleMouseClick = (event: MouseEvent) => {
       mousePosition.current = event.clientX;
     };
+    const updateWindowSize = () => {
+      setWindowSize(window.innerWidth);
+    };
+    updateWindowSize();
 
     window.addEventListener("mousedown", handleMouseClick);
-
+    window.addEventListener("resize", updateWindowSize);
     return () => {
+      window.removeEventListener("resize", updateWindowSize);
       window.removeEventListener("mousedown", handleMouseClick);
     };
   }, []);
 
+  const panelIsOpen = !!activePanelObject;
+  useEffect(() => {
+    if (panelIsOpen) {
+      const newObjectListingWidth =
+        (INITIAL_PANEL_PERCENTAGE * windowSize) / 100;
+      const previousPanelWidth = lastPanelWidth.get();
+      const computedPanelWidth =
+        previousPanelWidth || windowSize - newObjectListingWidth;
+      // Never open the Panel too small
+      const newPanelWidth =
+        computedPanelWidth >= MINIMUM_SIZES.panel
+          ? computedPanelWidth
+          : MINIMUM_SIZES.panel;
+      objectListingWidth.set(windowSize - newPanelWidth);
+      lastPanelWidth.set(undefined);
+    } else {
+      objectListingWidth.set(windowSize);
+    }
+  }, [panelIsOpen, objectListingWidth, windowSize, lastPanelWidth]);
+
   const handleDrag = useCallback(
     (_: PointerEvent, info: { delta: { x: number } }) => {
-      const width =
-        objectListingWidth.get() || objectListingRef?.current?.offsetWidth || 0;
-      const newWidth = width + info.delta.x;
-      if (newWidth > 425 && newWidth < windowSize - 375) {
-        objectListingWidth.set(newWidth);
+      const width = objectListingWidth.get() || windowSize || 0;
+      const newObjectListingWidth = width + info.delta.x;
+      if (
+        newObjectListingWidth > MINIMUM_SIZES.objectListing &&
+        newObjectListingWidth < windowSize - MINIMUM_SIZES.panel
+      ) {
+        objectListingWidth.set(newObjectListingWidth);
       }
     },
     [objectListingWidth, windowSize],
@@ -108,22 +137,19 @@ export const ContentLibrary = () => {
         ) : null}
       </DragOverlay>
       <div
-        className="flex h-screen flex-row"
+        className="flex h-screen w-full flex-row overflow-x-hidden"
+        ref={containerRef}
         style={{
           maxHeight: `calc(100vh - 5rem)`,
         }}
       >
         <m.div
-          ref={objectListingRef}
           className={clsx(
             "w-full max-w-full pt-6 pl-2 md:pl-6 lg:pl-10",
             activePanelObject && "md:w-1/2 lg:w-5/12 xl:w-3/5",
           )}
           style={{
-            width:
-              activePanelObject && objectListingWidth
-                ? objectListingWidth
-                : "100%",
+            width: objectListingWidth,
           }}
         >
           <ObjectList
@@ -135,12 +161,24 @@ export const ContentLibrary = () => {
         </m.div>
 
         {activePanelObject && (
-          <m.div className="fixed z-50 flex h-full w-full grow flex-row bg-white md:relative md:z-auto">
+          <m.div
+            className="fixed z-50 flex h-full w-full grow flex-row bg-white md:relative md:z-auto"
+            style={{ width: panelWidth }}
+          >
             <m.div
               data-testid="drag-bar"
               key={windowSize}
               className="hidden w-3 cursor-col-resize items-center bg-manatee-100 lg:flex "
               onDrag={handleDrag}
+              onDragStart={() => {
+                if (containerRef.current) {
+                  containerRef.current.classList.add("select-none");
+                }
+              }}
+              onDragEnd={() => {
+                if (containerRef.current)
+                  containerRef.current.classList.remove("select-none");
+              }}
               drag="x"
               dragConstraints={{ top: 0, left: 0, right: 0, bottom: 0 }}
               dragElastic={0}
@@ -148,15 +186,17 @@ export const ContentLibrary = () => {
             >
               <div className="mx-1 h-20 w-full rounded bg-manatee-600"></div>
             </m.div>
-            <Panel
-              closePanel={() => setActivePanelObject(null)}
-              uid={activePanelObject.uid}
-              objectType={activePanelObject.objectType}
-              language={activePanelObject.language}
-              showDropArea={!!draggedObject}
-              droppedObject={droppedObject}
-              clearDroppedObject={() => setDroppedObject(undefined)}
-            />
+            <div className="w-full overflow-x-scroll">
+              <Panel
+                closePanel={closePanel}
+                uid={activePanelObject.uid}
+                objectType={activePanelObject.objectType}
+                language={activePanelObject.language}
+                showDropArea={!!draggedObject}
+                droppedObject={droppedObject}
+                clearDroppedObject={() => setDroppedObject(undefined)}
+              />
+            </div>
           </m.div>
         )}
       </div>

--- a/src/components/objectIdentifierCard/objectIdentifier.component.tsx
+++ b/src/components/objectIdentifierCard/objectIdentifier.component.tsx
@@ -14,7 +14,7 @@ export const ObjectIdentifierCard = ({
   children,
 }: ObjectIdentifierCardProps) => {
   return (
-    <div className="flex w-full flex-grow space-x-2 py-3">
+    <div className="flex w-full flex-grow items-center space-x-2 py-3">
       <Pill
         label={object.objectType}
         bgColor={object.config.colour}

--- a/src/components/objectListing/objectListing.component.tsx
+++ b/src/components/objectListing/objectListing.component.tsx
@@ -56,7 +56,7 @@ export interface ObjectListProps {
 
 const createColumns = (
   columns: string[],
-  opts: { withObjectSelect?: boolean; withObjectEdit?: boolean },
+  opts: { withObjectSelect?: boolean },
   setPanelObject?: ObjectListProps["onInfoClick"],
 ) => {
   const objectTypeColumn = columnHelper.accessor(
@@ -144,23 +144,7 @@ const createColumns = (
 
   const actionColumn = columnHelper.display({
     id: OBJECT_LIST_TABLE.columnIds.actions,
-    cell: ({ table, row }) => {
-      const {
-        uid,
-        objectType,
-        meta: { language },
-      } = row.original as ParsedSkylarkObject;
-      return (
-        <RowActions
-          editRowEnabled={opts.withObjectEdit}
-          inEditMode={table.options.meta?.rowInEditMode === row.id}
-          onEditClick={() => table.options.meta?.onEditClick(row.id)}
-          onInfoClick={() => setPanelObject?.({ objectType, uid, language })}
-          onEditSaveClick={() => console.log(row)}
-          onEditCancelClick={() => table.options.meta?.onEditCancelClick()}
-        />
-      );
-    },
+    cell: (props) => <TableCell {...props} />,
   });
 
   const orderedColumnArray = [
@@ -184,7 +168,7 @@ const createColumns = (
 export const ObjectList = ({
   withCreateButtons,
   withObjectSelect,
-  withObjectEdit,
+  withObjectEdit = false,
   onInfoClick,
   isDragging,
   isPanelOpen,
@@ -224,13 +208,8 @@ export const ObjectList = ({
   }, [properties]);
 
   const parsedColumns = useMemo(
-    () =>
-      createColumns(
-        sortedHeaders,
-        { withObjectSelect, withObjectEdit },
-        onInfoClick,
-      ),
-    [sortedHeaders, withObjectEdit, withObjectSelect, onInfoClick],
+    () => createColumns(sortedHeaders, { withObjectSelect }, onInfoClick),
+    [sortedHeaders, withObjectSelect, onInfoClick],
   );
 
   const [rowInEditMode, setRowInEditMode] = useState("");
@@ -299,6 +278,7 @@ export const ObjectList = ({
     },
     meta: {
       rowInEditMode,
+      withObjectEdit,
       onEditClick(rowId) {
         setRowInEditMode(rowId);
       },

--- a/src/components/objectListing/table/table.component.tsx
+++ b/src/components/objectListing/table/table.component.tsx
@@ -12,8 +12,9 @@ import { useMemo } from "react";
 import { VirtualItem } from "react-virtual";
 
 import { Spinner } from "src/components/icons";
+import { RowActions } from "src/components/objectListing/rowActions";
 import { OBJECT_LIST_TABLE } from "src/constants/skylark";
-import { ParsedSkylarkObject } from "src/interfaces/skylark";
+import { ParsedSkylarkObject, SkylarkObjectType } from "src/interfaces/skylark";
 
 import { DisplayNameTableCell } from "./cell";
 
@@ -153,10 +154,12 @@ const TableData = ({
   cell,
   withCheckbox,
   tableMeta,
+  openPanel,
 }: {
   cell: Cell<ParsedSkylarkObject, unknown>;
   withCheckbox?: boolean;
   tableMeta: TableMeta<object> | undefined;
+  openPanel: () => void;
 }) => {
   const className = useMemo(
     () =>
@@ -193,6 +196,22 @@ const TableData = ({
     );
   }
 
+  if (cell.column.id === OBJECT_LIST_TABLE.columnIds.actions) {
+    const rowInEditMode = tableMeta?.rowInEditMode === cell.row.id || false;
+    return (
+      <td key={cell.id} className={className}>
+        <RowActions
+          editRowEnabled={tableMeta?.withObjectEdit}
+          inEditMode={rowInEditMode}
+          onEditClick={() => tableMeta?.onEditClick(cell.row.id)}
+          onInfoClick={openPanel}
+          onEditSaveClick={() => console.log(cell.row)}
+          onEditCancelClick={() => tableMeta?.onEditCancelClick()}
+        />
+      </td>
+    );
+  }
+
   return (
     <td key={cell.id} className={className}>
       {children}
@@ -220,6 +239,11 @@ const TableRow = ({
     },
     disabled: !withDraggableRow,
   });
+
+  const openPanel = () => {
+    setPanelObject?.({ uid, objectType, language });
+  };
+
   return (
     <tr
       ref={setNodeRef}
@@ -228,7 +252,7 @@ const TableRow = ({
       key={row.id}
       className={clsx("align-middle outline-none", rowClassName)}
       tabIndex={-1}
-      onDoubleClick={() => setPanelObject?.({ uid, objectType, language })}
+      onDoubleClick={openPanel}
       style={{
         height: `${virtualRowSize}px`,
       }}
@@ -239,6 +263,7 @@ const TableRow = ({
           key={cell.id}
           cell={cell}
           withCheckbox={withCheckbox}
+          openPanel={openPanel}
         />
       ))}
     </tr>

--- a/src/components/panel/panel.component.tsx
+++ b/src/components/panel/panel.component.tsx
@@ -152,7 +152,7 @@ export const Panel = ({
   };
 
   return (
-    <section className="mx-auto flex h-full w-full flex-col">
+    <section className="mx-auto flex h-full w-full flex-col break-words">
       <PanelHeader
         objectUid={uid}
         objectType={objectType}

--- a/src/components/panel/panelSections/panelHeader.component.tsx
+++ b/src/components/panel/panelSections/panelHeader.component.tsx
@@ -157,7 +157,7 @@ export const PanelHeader = ({
         )}
       </div>
       <div className="flex flex-col items-start pb-2">
-        <h1 className="truncate text-ellipsis w-full flex-grow text-lg font-bold uppercase md:text-xl">
+        <h1 className="w-full flex-grow truncate text-ellipsis text-lg font-bold uppercase md:text-xl">
           {title}
         </h1>
         {object && (

--- a/src/components/panel/panelSections/panelHeader.component.tsx
+++ b/src/components/panel/panelSections/panelHeader.component.tsx
@@ -157,7 +157,7 @@ export const PanelHeader = ({
         )}
       </div>
       <div className="flex flex-col items-start pb-2">
-        <h1 className="flex-grow text-lg font-bold uppercase md:text-xl">
+        <h1 className="truncate text-ellipsis flex-grow text-lg font-bold uppercase md:text-xl">
           {title}
         </h1>
         {object && (

--- a/src/components/panel/panelSections/panelHeader.component.tsx
+++ b/src/components/panel/panelSections/panelHeader.component.tsx
@@ -157,7 +157,7 @@ export const PanelHeader = ({
         )}
       </div>
       <div className="flex flex-col items-start pb-2">
-        <h1 className="truncate text-ellipsis flex-grow text-lg font-bold uppercase md:text-xl">
+        <h1 className="truncate text-ellipsis w-full flex-grow text-lg font-bold uppercase md:text-xl">
           {title}
         </h1>
         {object && (

--- a/src/components/panel/panelSections/panelMetadata.component.tsx
+++ b/src/components/panel/panelSections/panelMetadata.component.tsx
@@ -15,7 +15,7 @@ import {
   SkylarkObjectType,
   SkylarkSystemField,
 } from "src/interfaces/skylark";
-import { formatObjectField, hasProperty } from "src/lib/utils";
+import { formatObjectField } from "src/lib/utils";
 
 const systemFields: string[] = [
   SkylarkSystemField.UID,
@@ -26,13 +26,13 @@ const objectOptions: {
   objectTypes: SkylarkObjectType[];
   fieldsToHide: string[];
 }[] = [
-  {
-    objectTypes: [
-      BuiltInSkylarkObjectType.SkylarkImage,
-      BuiltInSkylarkObjectType.BetaSkylarkImage,
-    ],
-    fieldsToHide: ["external_url", "upload_url", "download_from_url"],
-  },
+  // {
+  //   objectTypes: [
+  //     BuiltInSkylarkObjectType.SkylarkImage,
+  //     BuiltInSkylarkObjectType.BetaSkylarkImage,
+  //   ],
+  //   fieldsToHide: ["external_url", "upload_url", "download_from_url"],
+  // },
 ];
 
 interface PanelMetadataProps {
@@ -139,7 +139,7 @@ export const PanelMetadata = ({
 
   return (
     <div
-      className="overflow-anywhere h-full overflow-y-auto p-4 pb-12 text-sm md:p-8 md:pb-20"
+      className="h-full overflow-y-auto p-4 pb-12 text-sm md:p-8 md:pb-20"
       data-testid="panel-metadata"
     >
       {metadata && (

--- a/src/components/panel/panelSections/panelMetadata.component.tsx
+++ b/src/components/panel/panelSections/panelMetadata.component.tsx
@@ -26,13 +26,13 @@ const objectOptions: {
   objectTypes: SkylarkObjectType[];
   fieldsToHide: string[];
 }[] = [
-  // {
-  //   objectTypes: [
-  //     BuiltInSkylarkObjectType.SkylarkImage,
-  //     BuiltInSkylarkObjectType.BetaSkylarkImage,
-  //   ],
-  //   fieldsToHide: ["external_url", "upload_url", "download_from_url"],
-  // },
+  {
+    objectTypes: [
+      BuiltInSkylarkObjectType.SkylarkImage,
+      BuiltInSkylarkObjectType.BetaSkylarkImage,
+    ],
+    fieldsToHide: ["external_url", "upload_url", "download_from_url"],
+  },
 ];
 
 interface PanelMetadataProps {

--- a/src/components/panel/panelSections/panelRelationships.component.tsx
+++ b/src/components/panel/panelSections/panelRelationships.component.tsx
@@ -34,7 +34,7 @@ export const PanelRelationships = ({
   >({});
 
   return (
-    <div className="overflow-anywhere relative h-full overflow-y-auto p-4 pb-12 text-sm md:p-8 md:pb-20">
+    <div className="relative h-full overflow-y-auto p-4 pb-12 text-sm md:p-8 md:pb-20">
       <div>
         {relationships &&
           relationships.map((relationship) => {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -4,6 +4,7 @@ export declare module "@tanstack/table-core" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface TableMeta<TData extends RowData> {
     rowInEditMode: string;
+    withObjectEdit: boolean;
     onEditClick: (rowId: string) => void;
     onEditCancelClick: () => void;
   }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -22,9 +22,6 @@
 }
 
 @layer utilities {
-  .overflow-anywhere {
-    overflow-wrap: anywhere;
-  }
 }
 
 /* Overrides for GraphiQL Explorer */


### PR DESCRIPTION
Fixes a few bugs with hopefully little performance impact:
1. [SL-2598] Text panel width on Safari. Fix: Track panel size, also track when closed so we can open it back at the users specified size
2. [SL-2462] Fix text selection when dragging panel sizer on Safari. Fix: useRef to add the `select-none` className when drag start and remove onDragEnd
3. [SL-2587] `i` icon not updating it's uid's when a new search entry appears. Fix: refactor where the icons are added in the code
4. [SL-2501] Panel resizes for a second when making a new search request. Fix: Track panel size
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Bugfix

#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://skylarkplatform.atlassian.net/browse/SL-2598
https://skylarkplatform.atlassian.net/browse/SL-2462
https://skylarkplatform.atlassian.net/browse/SL-2587
https://skylarkplatform.atlassian.net/browse/SL-2501