### PR TITLE
Bypass cache in GraphiQL

### DIFF
--- a/src/components/graphiqlEditor/graphiqlEditor.component.tsx
+++ b/src/components/graphiqlEditor/graphiqlEditor.component.tsx
@@ -68,7 +68,7 @@ export const GraphiQLEditor = ({
           Accept: "application/json",
           "Content-Type": "application/json",
           [REQUEST_HEADERS.apiKey]: token,
-          [REQUEST_HEADERS.betaApiKey]: token,
+          [REQUEST_HEADERS.bypassCache]: "1",
           ...opts?.headers,
         },
         body: JSON.stringify(graphQLParams),
@@ -85,6 +85,7 @@ export const GraphiQLEditor = ({
       setExplorerQuery(updatedQuery);
       setQuery(updatedQuery);
     },
+    showAttribution: false,
   });
 
   return (

--- a/src/constants/skylark.ts
+++ b/src/constants/skylark.ts
@@ -13,7 +13,6 @@ export const SAAS_API_KEY = (process.env.NEXT_PUBLIC_SAAS_API_KEY ||
   process.env.SAAS_API_KEY) as string;
 export const REQUEST_HEADERS = {
   apiKey: "Authorization",
-  betaApiKey: "x-api-key",
   bypassCache: "x-bypass-cache",
 };
 export const OBJECT_LIST_TABLE = {

--- a/src/hooks/useConnectedToSkylark.tsx
+++ b/src/hooks/useConnectedToSkylark.tsx
@@ -40,7 +40,6 @@ export const useConnectedToSkylark = () => {
             {},
             {
               [REQUEST_HEADERS.apiKey]: token,
-              [REQUEST_HEADERS.betaApiKey]: token,
               [REQUEST_HEADERS.bypassCache]: "1",
             },
           );

--- a/src/lib/graphql/skylark/client.ts
+++ b/src/lib/graphql/skylark/client.ts
@@ -12,7 +12,7 @@ export const createSkylarkClient = (uri: string, token: string) =>
   new GraphQLClient(uri, {
     headers: {
       [REQUEST_HEADERS.apiKey]: token,
-      [REQUEST_HEADERS.betaApiKey]: token,
+      [REQUEST_HEADERS.bypassCache]: "1",
     },
   });
 
@@ -40,7 +40,6 @@ export const skylarkRequest = <T>(
 
   const headers: HeadersInit = {
     [REQUEST_HEADERS.apiKey]: tokenToSend,
-    [REQUEST_HEADERS.betaApiKey]: tokenToSend,
   };
 
   if (!opts?.useCache) {


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->
- Adds the bypass-cache header to the GraphQL Explorer
- Removes the old auth header

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Bugfix

