### PR TITLE
feat: Add Infinite Scroll to Object Content panel, prefetch availability on load

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -9,13 +9,7 @@ import { initialize as initializeMsw, mswDecorator } from "msw-storybook-addon";
 import PlausibleProvider from "next-plausible";
 import "react-toastify/dist/ReactToastify.min.css";
 
-import {
-  getObjectAvailabilityHandlers,
-  getObjectHandlers,
-} from "../src/__tests__/mocks/handlers/getObjectHandlers";
-import { introspectionHandlers } from "../src/__tests__/mocks/handlers/introspectionHandlers";
-import { searchHandlers } from "../src/__tests__/mocks/handlers/searchHandlers";
-import { updateObjectHandlers } from "../src/__tests__/mocks/handlers/updateObjectHandlers";
+import { handlers } from "../src/__tests__/mocks/handlers";
 import { UserProvider } from "../src/contexts/useUser";
 import "../src/styles/globals.css";
 
@@ -33,13 +27,7 @@ export const parameters = {
   },
   // Global MSW handlers
   msw: {
-    handlers: {
-      introspection: introspectionHandlers,
-      search: searchHandlers,
-      getObject: getObjectHandlers,
-      getObjectAvailability: getObjectAvailabilityHandlers,
-      updateObject: updateObjectHandlers,
-    },
+    handlers: handlers,
   },
 };
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <h3 align="center">Skylark UI</h3>
 
   <p align="center">
-    Curation UI for Skylark X
+    Curation UI for Skylark
     <br />
     <a href="https://www.skylarkplatform.com/"><strong>Learn more »</strong></a>
     <br />

--- a/cypress/e2e/contentLibrary/objectPanel.cy.ts
+++ b/cypress/e2e/contentLibrary/objectPanel.cy.ts
@@ -590,19 +590,6 @@ describe("Content Library - Object Panel", () => {
       cy.wait("@updateHomepageSetContent");
 
       cy.contains("button", "Edit Content").should("not.be.disabled");
-
-      cy.get("[data-testid=panel-content-items] > li p")
-        .then(($els) => {
-          const text = $els.toArray().map((el) => el.innerText.trim());
-          return text;
-        })
-        .should("deep.eq", [
-          "Spotlight movies",
-          "New TV Releases",
-          "GOT Season 1",
-          "GOT Season 2",
-          "Home page hero",
-        ]);
     });
   });
 

--- a/cypress/e2e/contentLibrary/objectPanel.cy.ts
+++ b/cypress/e2e/contentLibrary/objectPanel.cy.ts
@@ -386,6 +386,10 @@ describe("Content Library - Object Panel", () => {
           // Check back button returns to the original object
           cy.get('[aria-label="Click to go back"]').click();
           cy.get(`[data-cy=panel-for-${episodeObjectType}-${episodeUid}]`);
+
+          // Check forward button returns to the image object
+          cy.get('[aria-label="Click to go forward"]').click();
+          cy.get(`[data-cy=panel-for-SkylarkImage-${firstImageUid}]`);
         },
       );
     });
@@ -436,6 +440,12 @@ describe("Content Library - Object Panel", () => {
               cy.get('[aria-label="Click to go back"]').click();
               cy.get(
                 `[data-cy=panel-for-${homepageObjectType}-${homepageUid}]`,
+              );
+
+              // Check forward button returns to the content object
+              cy.get('[aria-label="Click to go forward"]').click();
+              cy.get(
+                `[data-cy=panel-for-${firstSetContentItemObjectType}-${firstSetContentItemUid}]`,
               );
             });
         },
@@ -645,6 +655,12 @@ describe("Content Library - Object Panel", () => {
           // Check back button returns to the original object
           cy.get('[aria-label="Click to go back"]').click();
           cy.get(`[data-cy=panel-for-${objectType}-${objectUid}]`);
+
+          // Check forward button returns to the availability object
+          cy.get('[aria-label="Click to go forward"]').click();
+          cy.get(
+            `[data-cy=panel-for-Availability-${availabilityJson.data.getObjectAvailability.availability.objects[0].uid}]`,
+          );
         });
       });
     });

--- a/cypress/e2e/contentLibrary/objectPanel.cy.ts
+++ b/cypress/e2e/contentLibrary/objectPanel.cy.ts
@@ -52,6 +52,11 @@ describe("Content Library - Object Panel", () => {
           fixture: "./skylark/queries/getObject/homepage.json",
         });
       }
+      if (hasOperationName(req, "GET_SkylarkSet_CONTENT")) {
+        req.reply({
+          fixture: "./skylark/queries/getObjectContent/homepage.json",
+        });
+      }
       if (hasOperationName(req, "GET_Movie")) {
         req.reply({
           fixture:
@@ -379,7 +384,7 @@ describe("Content Library - Object Panel", () => {
           cy.get(`[data-cy=panel-for-SkylarkImage-${firstImageUid}]`);
 
           // Check back button returns to the original object
-          cy.get('[aria-label="Open Previous Object"]').click();
+          cy.get('[aria-label="Click to go back"]').click();
           cy.get(`[data-cy=panel-for-${episodeObjectType}-${episodeUid}]`);
         },
       );
@@ -399,30 +404,40 @@ describe("Content Library - Object Panel", () => {
     it("navigates to the set content using the object button", () => {
       cy.fixture("./skylark/queries/getObject/homepage.json").then(
         (homepageJson) => {
-          const homepageUid = homepageJson.data.getObject.uid;
-          const homepageObjectType = homepageJson.data.getObject.__typename;
-          const firstSetContentItemUid =
-            homepageJson.data.getObject.content.objects[0].object.uid;
-          const firstSetContentItemObjectType =
-            homepageJson.data.getObject.content.objects[0].object.__typename;
+          return cy
+            .fixture("./skylark/queries/getObjectContent/homepage.json")
+            .then((homepageContentJson) => {
+              const homepageUid = homepageJson.data.getObject.uid;
+              const homepageObjectType = homepageJson.data.getObject.__typename;
+              const firstSetContentItemUid =
+                homepageContentJson.data.getObjectContent.content.objects[0]
+                  .object.uid;
+              const firstSetContentItemObjectType =
+                homepageContentJson.data.getObjectContent.content.objects[0]
+                  .object.__typename;
 
-          cy.get('input[name="search-query-input"]').type("Homepage");
-          cy.contains("Homepage").should("exist");
-          cy.openContentLibraryObjectPanelByText("Homepage");
+              cy.get('input[name="search-query-input"]').type("Homepage");
+              cy.contains("Homepage").should("exist");
+              cy.openContentLibraryObjectPanelByText("Homepage");
 
-          cy.contains("button", "Content").click();
-          cy.get(`[data-cy=panel-for-${homepageObjectType}-${homepageUid}]`);
+              cy.contains("button", "Content").click();
+              cy.get(
+                `[data-cy=panel-for-${homepageObjectType}-${homepageUid}]`,
+              );
 
-          cy.get('[aria-label="Open Object"]').first().click();
+              cy.get('[aria-label="Open Object"]').first().click();
 
-          // Only check the panel object type and uid so we don't have to mock the response
-          cy.get(
-            `[data-cy=panel-for-${firstSetContentItemObjectType}-${firstSetContentItemUid}]`,
-          );
+              // Only check the panel object type and uid so we don't have to mock the response
+              cy.get(
+                `[data-cy=panel-for-${firstSetContentItemObjectType}-${firstSetContentItemUid}]`,
+              );
 
-          // Check back button returns to the original object
-          cy.get('[aria-label="Open Previous Object"]').click();
-          cy.get(`[data-cy=panel-for-${homepageObjectType}-${homepageUid}]`);
+              // Check back button returns to the original object
+              cy.get('[aria-label="Click to go back"]').click();
+              cy.get(
+                `[data-cy=panel-for-${homepageObjectType}-${homepageUid}]`,
+              );
+            });
         },
       );
     });
@@ -433,6 +448,10 @@ describe("Content Library - Object Panel", () => {
       cy.openContentLibraryObjectPanelByText("Homepage");
 
       cy.contains("button", "Content").click();
+
+      cy.get("[data-testid=panel-content-items]").within(() => {
+        cy.contains("Home page hero");
+      });
 
       // Test switching to edit mode
       cy.contains("Editing").should("not.exist");
@@ -453,19 +472,19 @@ describe("Content Library - Object Panel", () => {
           "New TV Releases",
           "GOT Season 1",
           "GOT Season 2",
-          "Discover Collection",
+          "Discover",
         ]);
 
       cy.percySnapshot("Homepage - object panel - content (edit)");
 
       // Test deleting
-      cy.contains("Discover Collection")
+      cy.contains("Discover")
         .parent()
         .parent()
         .within(() => {
           cy.get("[data-testid=object-identifier-delete]").click();
         });
-      cy.contains("Discover Collection").should("not.exist");
+      cy.contains("Discover").should("not.exist");
 
       // Test reorder
       cy.get("[data-testid=panel-content-items] > li")
@@ -507,7 +526,7 @@ describe("Content Library - Object Panel", () => {
           "New TV Releases",
           "GOT Season 1",
           "GOT Season 2",
-          "Discover Collection",
+          "Discover",
         ]);
     });
 
@@ -518,11 +537,15 @@ describe("Content Library - Object Panel", () => {
 
       cy.contains("button", "Content").click();
 
+      cy.get("[data-testid=panel-content-items]").within(() => {
+        cy.contains("Home page hero");
+      });
+
       // Test switching to edit mode
       cy.contains("button", "Edit Content").should("not.be.disabled").click();
 
       // Delete
-      cy.contains("Discover Collection")
+      cy.contains("Discover")
         .parent()
         .parent()
         .within(() => {
@@ -620,7 +643,7 @@ describe("Content Library - Object Panel", () => {
           );
 
           // Check back button returns to the original object
-          cy.get('[aria-label="Open Previous Object"]').click();
+          cy.get('[aria-label="Click to go back"]').click();
           cy.get(`[data-cy=panel-for-${objectType}-${objectUid}]`);
         });
       });

--- a/cypress/e2e/import/csv.cy.ts
+++ b/cypress/e2e/import/csv.cy.ts
@@ -137,18 +137,21 @@ describe("Import/CSV", () => {
       cy.on("window:before:load", (win) => {
         win.WebSocket = WebSocket;
         mockGraphQlSocket.on("connection", (socket) => {
-          socket.on("message", (data: string) => {
-            const { id } = JSON.parse(data);
-            if (id === "1") {
-              socket.send(
-                JSON.stringify({
-                  type: "data",
-                  id: "1",
-                  payload,
-                }),
-              );
-            }
-          });
+          socket.on(
+            "message",
+            (message: string | ArrayBuffer | Blob | ArrayBufferView) => {
+              const { id } = JSON.parse(message as string);
+              if (id === "1") {
+                socket.send(
+                  JSON.stringify({
+                    type: "data",
+                    id: "1",
+                    payload,
+                  }),
+                );
+              }
+            },
+          );
         });
       });
 

--- a/cypress/e2e/objectPage.cy.ts
+++ b/cypress/e2e/objectPage.cy.ts
@@ -72,27 +72,35 @@ describe("Object Page", () => {
     it("navigates to Content tab, opens an object and checks the URL has updated", () => {
       cy.fixture("./skylark/queries/getObject/homepage.json").then(
         (homepageJson) => {
-          const homepageUid = homepageJson.data.getObject.uid;
-          const homepageObjectType = homepageJson.data.getObject.__typename;
-          const firstSetContentItemUid =
-            homepageJson.data.getObject.content.objects[0].object.uid;
-          const firstSetContentItemObjectType =
-            homepageJson.data.getObject.content.objects[0].object.__typename;
+          return cy
+            .fixture("./skylark/queries/getObjectContent/homepage.json")
+            .then((homepageContentJson) => {
+              const homepageUid = homepageJson.data.getObject.uid;
+              const homepageObjectType = homepageJson.data.getObject.__typename;
+              const firstSetContentItemUid =
+                homepageContentJson.data.getObjectContent.content.objects[0]
+                  .object.uid;
+              const firstSetContentItemObjectType =
+                homepageContentJson.data.getObjectContent.content.objects[0]
+                  .object.__typename;
 
-          cy.contains("button", "Content").click();
-          cy.get(`[data-cy=panel-for-${homepageObjectType}-${homepageUid}]`);
+              cy.contains("button", "Content").click();
+              cy.get(
+                `[data-cy=panel-for-${homepageObjectType}-${homepageUid}]`,
+              );
 
-          cy.get('[aria-label="Open Object"]').first().click();
+              cy.get('[aria-label="Open Object"]').first().click();
 
-          // Only check the panel object type and uid so we don't have to mock the response
-          cy.get(
-            `[data-cy=panel-for-${firstSetContentItemObjectType}-${firstSetContentItemUid}]`,
-          );
+              // Only check the panel object type and uid so we don't have to mock the response
+              cy.get(
+                `[data-cy=panel-for-${firstSetContentItemObjectType}-${firstSetContentItemUid}]`,
+              );
 
-          cy.url().should(
-            "include",
-            `/object/${firstSetContentItemObjectType}/${firstSetContentItemUid}`,
-          );
+              cy.url().should(
+                "include",
+                `/object/${firstSetContentItemObjectType}/${firstSetContentItemUid}`,
+              );
+            });
         },
       );
     });

--- a/cypress/e2e/objectPage.cy.ts
+++ b/cypress/e2e/objectPage.cy.ts
@@ -37,6 +37,11 @@ describe("Object Page", () => {
           fixture: "./skylark/queries/getObject/homepage.json",
         });
       }
+      if (hasOperationName(req, "GET_SkylarkSet_CONTENT")) {
+        req.reply({
+          fixture: "./skylark/queries/getObjectContent/homepage.json",
+        });
+      }
     });
   });
 

--- a/src/__tests__/fixtures/skylark/queries/getObject/homepage.json
+++ b/src/__tests__/fixtures/skylark/queries/getObject/homepage.json
@@ -9,10 +9,15 @@
       },
       "_meta": {
         "available_languages": ["en-GB", "pt-PT"],
-        "language_data": { "language": "en-GB", "version": 1 },
-        "global_data": { "version": 2 }
+        "language_data": {
+          "language": "en-GB",
+          "version": 1
+        },
+        "global_data": {
+          "version": 2
+        }
       },
-      "uid": "01GXZP42M2RNMRQQ0EV3DRHCMW",
+      "uid": "01H38V1C0BNDWHNKSPGDKVXVS1",
       "slug": "media-reference-homepage",
       "external_id": "streamtv_homepage",
       "type": "PAGE",
@@ -27,11 +32,11 @@
         "next_token": null,
         "objects": [
           {
-            "uid": "01GXZNX7Q25B2ED3VB1KDA248M",
-            "external_id": "recXNjJNyc6nKQIYa",
-            "title": "Always - All devices, all customer types",
-            "slug": "always-all-devices-all-customer-types",
-            "start": "2022-01-01T00:00:00+00:00",
+            "uid": "01H38TTY30A0GYM6ZARCGCH0N7",
+            "external_id": "recR7MXtwMj6MR8TK",
+            "title": "Always - everything",
+            "slug": "always-everything",
+            "start": "2000-01-01T15:15:00+00:00",
             "end": "2038-01-19T03:14:07+00:00",
             "timezone": "+00:00"
           }
@@ -43,225 +48,65 @@
           {
             "_meta": {
               "available_languages": ["en-GB"],
-              "language_data": { "language": "en-GB", "version": 2 },
-              "global_data": { "version": 2 }
+              "language_data": {
+                "language": "en-GB",
+                "version": 1
+              },
+              "global_data": {
+                "version": 1
+              }
             },
-            "uid": "01GXZNXH7S0NTPCACFEHEMX7NF",
-            "external_id": "reckauU2wr4Jmo3BD",
-            "slug": null,
-            "title": "TopOfHomepage.png",
-            "description": null,
-            "type": "MAIN",
-            "url": "https://dl.airtable.com/.attachments/9d126fbf6638187bdf6fa5f7749ffeca/eb24fc2d/TopOfHomepage.png",
-            "external_url": "https://dl.airtable.com/.attachments/9d126fbf6638187bdf6fa5f7749ffeca/eb24fc2d/TopOfHomepage.png",
-            "upload_url": "https://obj-reg-storage-sl-develop-eu-west-1-storage.s3.amazonaws.com/media/skylarkimages/vrdlihwc4ves3ihxxzrykjpvvm/01GXZNXH7S0NTPCACFEHEMX7NF/01GXZPP4169H543VQT7PWPETXH?AWSAccessKeyId=ASIA4YDX3EVVD2BOM24K&Signature=wxlJHo1hmRG%2BwOE3HgQumPvy3Sc%3D&content-type=application%2Foctet&x-amz-meta-account_id=vrdlihwc4ves3ihxxzrykjpvvm&x-amz-meta-uid=01GXZNXH7S0NTPCACFEHEMX7NF&x-amz-security-token=IQoJb3JpZ2luX2VjEAMaCWV1LXdlc3QtMSJGMEQCIGqjCXO0Ejkdoa45EieM4UGRcPsPTNqtbLvTxbYekyoKAiBcnDmYAJHLix7m6AqK8xhWfVtADzBEIPRI%2FvifV5QVqyq0Awjs%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F8BEAAaDDg3NjQyNDY2ODUyMiIMexT%2FLNSGMJQnbIwqKogDkUx3dqx0ZQugn6bb1CDVMDJnJOVjDnLWjmbKs29rshAhP%2BwMo7dK2IPpovcOnAINEcyQ9ov%2Fgvc3HQTz0CBf6PDDdwXWXtg0Mh6rk095CKexwbLynECEGNJpMFsTJtYGcsvI%2F4LyTA%2BxskZf9BGqIYLrxxhCM%2FzZi8ySsaTeprx57hhFA9nv5UrZI%2F1Jwp00UEyJkiEFVaVv1sMh3C%2BAxoYoeqxBpAI%2FutC%2BweaKTML79ESV4BA6Uy0EVH5xE%2BojG9pQSp7YHXgAFyIyIt3Tw%2F5Eg2k8%2FtrO5DkTRcYc9RDVBgmm8oJw1wTqSx5Mpal2KqwxQxiMarRZ8LVxdsbpthBTnxNDZy%2Ba%2FHU%2FcFjNB%2BNdBz9ANbhWJSMRcJ1dfUtVlJzDMwOETL7FmZ8DrwIEuRWWelq2mdbO2SZFFrA806Uve855i%2F1e5RnG1qTa0Eq3LOJ2KR3%2FIoMv6DYkA1f4bSe2CnK6xSBzlixeBuK5fXPkAPDI7ck3lEocOwmC%2BNiJOnfsS3TML4gwzt3koQY6ngHQF2W6gjj082uLT7%2B2aadFbEIBYQ%2BhGrLWkapVOAkG4kLpfyk35qVRtyJRDI9zPAMaV43P3GlIUGK1XePPZcXHSL4PdGC7nGo1wTb8v14OwfIqRglVfQJe9VNMkst6fhaLtuZQ%2FGA49%2FCdYAfeWBI3%2BD7X7MH1d%2B4GaPMljAkCyG32LEM39WLfv%2F3Lu%2FcNn6mHwCJJ%2BIPUOf9K2tvKPg%3D%3D&Expires=1681473535",
-            "download_from_url": null,
-            "file_name": null,
-            "content_type": null
-          },
-          {
-            "_meta": {
-              "available_languages": ["en-GB"],
-              "language_data": { "language": "en-GB", "version": 2 },
-              "global_data": { "version": 2 }
-            },
-            "uid": "01GXZNXNKEQ8AJJ59K272QXDWE",
-            "external_id": "recgkAKiElyJeSpvy",
-            "slug": null,
-            "title": "StreamTVLoadingScreen.png",
-            "description": null,
-            "type": "MAIN",
-            "url": "https://dl.airtable.com/.attachments/caec77d4d303b706499172d09d6389c7/b6497292/StreamTVLoadingScreen.png",
-            "external_url": "https://dl.airtable.com/.attachments/caec77d4d303b706499172d09d6389c7/b6497292/StreamTVLoadingScreen.png",
-            "upload_url": "https://obj-reg-storage-sl-develop-eu-west-1-storage.s3.amazonaws.com/media/skylarkimages/vrdlihwc4ves3ihxxzrykjpvvm/01GXZNXNKEQ8AJJ59K272QXDWE/01GXZPP3ZWRC6BTEVBMF42AYS7?AWSAccessKeyId=ASIA4YDX3EVVD2BOM24K&Signature=nwZhDLxmgNU85MyMW680zVlRuu4%3D&content-type=application%2Foctet&x-amz-meta-account_id=vrdlihwc4ves3ihxxzrykjpvvm&x-amz-meta-uid=01GXZNXNKEQ8AJJ59K272QXDWE&x-amz-security-token=IQoJb3JpZ2luX2VjEAMaCWV1LXdlc3QtMSJGMEQCIGqjCXO0Ejkdoa45EieM4UGRcPsPTNqtbLvTxbYekyoKAiBcnDmYAJHLix7m6AqK8xhWfVtADzBEIPRI%2FvifV5QVqyq0Awjs%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F8BEAAaDDg3NjQyNDY2ODUyMiIMexT%2FLNSGMJQnbIwqKogDkUx3dqx0ZQugn6bb1CDVMDJnJOVjDnLWjmbKs29rshAhP%2BwMo7dK2IPpovcOnAINEcyQ9ov%2Fgvc3HQTz0CBf6PDDdwXWXtg0Mh6rk095CKexwbLynECEGNJpMFsTJtYGcsvI%2F4LyTA%2BxskZf9BGqIYLrxxhCM%2FzZi8ySsaTeprx57hhFA9nv5UrZI%2F1Jwp00UEyJkiEFVaVv1sMh3C%2BAxoYoeqxBpAI%2FutC%2BweaKTML79ESV4BA6Uy0EVH5xE%2BojG9pQSp7YHXgAFyIyIt3Tw%2F5Eg2k8%2FtrO5DkTRcYc9RDVBgmm8oJw1wTqSx5Mpal2KqwxQxiMarRZ8LVxdsbpthBTnxNDZy%2Ba%2FHU%2FcFjNB%2BNdBz9ANbhWJSMRcJ1dfUtVlJzDMwOETL7FmZ8DrwIEuRWWelq2mdbO2SZFFrA806Uve855i%2F1e5RnG1qTa0Eq3LOJ2KR3%2FIoMv6DYkA1f4bSe2CnK6xSBzlixeBuK5fXPkAPDI7ck3lEocOwmC%2BNiJOnfsS3TML4gwzt3koQY6ngHQF2W6gjj082uLT7%2B2aadFbEIBYQ%2BhGrLWkapVOAkG4kLpfyk35qVRtyJRDI9zPAMaV43P3GlIUGK1XePPZcXHSL4PdGC7nGo1wTb8v14OwfIqRglVfQJe9VNMkst6fhaLtuZQ%2FGA49%2FCdYAfeWBI3%2BD7X7MH1d%2B4GaPMljAkCyG32LEM39WLfv%2F3Lu%2FcNn6mHwCJJ%2BIPUOf9K2tvKPg%3D%3D&Expires=1681473535",
-            "download_from_url": null,
-            "file_name": null,
-            "content_type": null
-          },
-          {
-            "_meta": {
-              "available_languages": ["en-GB"],
-              "language_data": { "language": "en-GB", "version": 2 },
-              "global_data": { "version": 2 }
-            },
-            "uid": "01GXZNXE4CKA7FBF61M7QEZAWJ",
+            "uid": "01H38TVV5GAN2RHTPBVZC2C3BG",
             "external_id": "recBiJpHfAYK1sPiI",
             "slug": null,
             "title": "HomepageAfterCarousel.png",
             "description": null,
             "type": "MAIN",
-            "url": "https://dl.airtable.com/.attachments/ec508b5317f19fee0c50ed9238d23588/02a5d627/HomepageAfterCarousel.png",
-            "external_url": "https://dl.airtable.com/.attachments/ec508b5317f19fee0c50ed9238d23588/02a5d627/HomepageAfterCarousel.png",
-            "upload_url": "https://obj-reg-storage-sl-develop-eu-west-1-storage.s3.amazonaws.com/media/skylarkimages/vrdlihwc4ves3ihxxzrykjpvvm/01GXZNXE4CKA7FBF61M7QEZAWJ/01GXZPP40C68TE6QBKPNMGSKQF?AWSAccessKeyId=ASIA4YDX3EVVD2BOM24K&Signature=FPwuhwaaVdRCNTfUv5hXlX0h0eI%3D&content-type=application%2Foctet&x-amz-meta-account_id=vrdlihwc4ves3ihxxzrykjpvvm&x-amz-meta-uid=01GXZNXE4CKA7FBF61M7QEZAWJ&x-amz-security-token=IQoJb3JpZ2luX2VjEAMaCWV1LXdlc3QtMSJGMEQCIGqjCXO0Ejkdoa45EieM4UGRcPsPTNqtbLvTxbYekyoKAiBcnDmYAJHLix7m6AqK8xhWfVtADzBEIPRI%2FvifV5QVqyq0Awjs%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F8BEAAaDDg3NjQyNDY2ODUyMiIMexT%2FLNSGMJQnbIwqKogDkUx3dqx0ZQugn6bb1CDVMDJnJOVjDnLWjmbKs29rshAhP%2BwMo7dK2IPpovcOnAINEcyQ9ov%2Fgvc3HQTz0CBf6PDDdwXWXtg0Mh6rk095CKexwbLynECEGNJpMFsTJtYGcsvI%2F4LyTA%2BxskZf9BGqIYLrxxhCM%2FzZi8ySsaTeprx57hhFA9nv5UrZI%2F1Jwp00UEyJkiEFVaVv1sMh3C%2BAxoYoeqxBpAI%2FutC%2BweaKTML79ESV4BA6Uy0EVH5xE%2BojG9pQSp7YHXgAFyIyIt3Tw%2F5Eg2k8%2FtrO5DkTRcYc9RDVBgmm8oJw1wTqSx5Mpal2KqwxQxiMarRZ8LVxdsbpthBTnxNDZy%2Ba%2FHU%2FcFjNB%2BNdBz9ANbhWJSMRcJ1dfUtVlJzDMwOETL7FmZ8DrwIEuRWWelq2mdbO2SZFFrA806Uve855i%2F1e5RnG1qTa0Eq3LOJ2KR3%2FIoMv6DYkA1f4bSe2CnK6xSBzlixeBuK5fXPkAPDI7ck3lEocOwmC%2BNiJOnfsS3TML4gwzt3koQY6ngHQF2W6gjj082uLT7%2B2aadFbEIBYQ%2BhGrLWkapVOAkG4kLpfyk35qVRtyJRDI9zPAMaV43P3GlIUGK1XePPZcXHSL4PdGC7nGo1wTb8v14OwfIqRglVfQJe9VNMkst6fhaLtuZQ%2FGA49%2FCdYAfeWBI3%2BD7X7MH1d%2B4GaPMljAkCyG32LEM39WLfv%2F3Lu%2FcNn6mHwCJJ%2BIPUOf9K2tvKPg%3D%3D&Expires=1681473535",
-            "download_from_url": null,
+            "url": "https://media.showcase.skylarkplatform.com/skylarkimages/mt3lb55zorcg7mu3mn62gzr5ne/01H38TVV5GAN2RHTPBVZC2C3BG/01H38TVW496NC3SKYDNSWK6PJC",
             "file_name": null,
-            "content_type": null
-          }
-        ]
-      },
-      "content": {
-        "objects": [
-          {
-            "object": {
-              "__typename": "SkylarkSet",
-              "_config": {
-                "primary_field": "title",
-                "colour": "#000000",
-                "display_name": "Setˢˡ"
-              },
-              "_meta": {
-                "available_languages": ["en-GB", "pt-PT"],
-                "language_data": { "language": "en-GB", "version": 1 },
-                "global_data": { "version": 2 }
-              },
-              "uid": "01GXZP3KGDESE0M305HM7PKTAE",
-              "__SkylarkSet__slug": "media-reference-home-page-hero",
-              "external_id": null,
-              "__SkylarkSet__type": "SLIDER",
-              "__SkylarkSet__title": "Home page hero",
-              "__SkylarkSet__title_short": null,
-              "__SkylarkSet__title_sort": null,
-              "__SkylarkSet__synopsis": null,
-              "__SkylarkSet__synopsis_short": null,
-              "__SkylarkSet__release_date": null,
-              "__SkylarkSet__description": null
-            },
-            "position": 1
+            "content_type": "image/png"
           },
           {
-            "object": {
-              "__typename": "SkylarkSet",
-              "_config": {
-                "primary_field": "title",
-                "colour": "#000000",
-                "display_name": "Setˢˡ"
+            "_meta": {
+              "available_languages": ["en-GB"],
+              "language_data": {
+                "language": "en-GB",
+                "version": 1
               },
-              "_meta": {
-                "available_languages": ["en-GB", "pt-PT"],
-                "language_data": { "language": "en-GB", "version": 1 },
-                "global_data": { "version": 2 }
-              },
-              "uid": "01GXZP3F8V13R6BQ3F6VC8KK7J",
-              "__SkylarkSet__slug": "spotlight-movies",
-              "external_id": "streamtv_spotlight_movies",
-              "__SkylarkSet__type": "RAIL",
-              "__SkylarkSet__title": "Spotlight movies",
-              "__SkylarkSet__title_short": "Latest releases",
-              "__SkylarkSet__title_sort": null,
-              "__SkylarkSet__synopsis": null,
-              "__SkylarkSet__synopsis_short": null,
-              "__SkylarkSet__release_date": null,
-              "__SkylarkSet__description": null
+              "global_data": {
+                "version": 1
+              }
             },
-            "position": 2
+            "uid": "01H38TVFRWJ9MKCS2T70BD0Q8C",
+            "external_id": "recgkAKiElyJeSpvy",
+            "slug": null,
+            "title": "StreamTVLoadingScreen.png",
+            "description": null,
+            "type": "MAIN",
+            "url": "https://media.showcase.skylarkplatform.com/skylarkimages/mt3lb55zorcg7mu3mn62gzr5ne/01H38TVFRWJ9MKCS2T70BD0Q8C/01H38TVGNT7VY4V27Z3Y2PHYT0",
+            "file_name": null,
+            "content_type": "image/png"
           },
           {
-            "object": {
-              "__typename": "SkylarkSet",
-              "_config": {
-                "primary_field": "title",
-                "colour": "#000000",
-                "display_name": "Setˢˡ"
+            "_meta": {
+              "available_languages": ["en-GB"],
+              "language_data": {
+                "language": "en-GB",
+                "version": 1
               },
-              "_meta": {
-                "available_languages": ["en-GB", "pt-PT"],
-                "language_data": { "language": "en-GB", "version": 1 },
-                "global_data": { "version": 2 }
-              },
-              "uid": "01GXZP3DNTEHF45AXZ4P3JBVEA",
-              "__SkylarkSet__slug": "new-tv-releases",
-              "external_id": "streamtv_new_tv_releases",
-              "__SkylarkSet__type": "RAIL",
-              "__SkylarkSet__title": "New TV Releases",
-              "__SkylarkSet__title_short": "Premium TV",
-              "__SkylarkSet__title_sort": null,
-              "__SkylarkSet__synopsis": null,
-              "__SkylarkSet__synopsis_short": null,
-              "__SkylarkSet__release_date": null,
-              "__SkylarkSet__description": null
+              "global_data": {
+                "version": 1
+              }
             },
-            "position": 3
-          },
-          {
-            "object": {
-              "__typename": "Season",
-              "_config": {
-                "primary_field": "title",
-                "colour": "#9c27b0",
-                "display_name": "Season"
-              },
-              "_meta": {
-                "available_languages": ["en-GB", "pt-PT"],
-                "language_data": { "language": "en-GB", "version": 1 },
-                "global_data": { "version": 2 }
-              },
-              "uid": "01GXZP27HSF7NJYVTYHS7NDQ3P",
-              "external_id": "recNWXkYGdriyverR",
-              "__Season__slug": "got-s01",
-              "__Season__synopsis": "In the mythical continent of Westeros, several powerful families fight for control of the Seven Kingdoms. As conflict erupts in the kingdoms of men, an ancient enemy rises once again to threaten them all. Meanwhile, the last heirs of a recently usurped dynasty plot to take back their homeland from across the Narrow Sea.",
-              "__Season__synopsis_short": null,
-              "__Season__title": "GOT Season 1",
-              "__Season__title_short": "GOT S01",
-              "__Season__title_sort": null,
-              "__Season__number_of_episodes": null,
-              "__Season__release_date": "2011-04-17",
-              "__Season__season_number": 1
-            },
-            "position": 4
-          },
-          {
-            "object": {
-              "__typename": "Season",
-              "_config": {
-                "primary_field": "title",
-                "colour": "#9c27b0",
-                "display_name": "Season"
-              },
-              "_meta": {
-                "available_languages": ["en-GB", "pt-PT"],
-                "language_data": { "language": "en-GB", "version": 1 },
-                "global_data": { "version": 2 }
-              },
-              "uid": "01GXZP256PY1A3FSH3WX85SDHP",
-              "external_id": "rec6brp07XJZ5iFla",
-              "__Season__slug": "got-s02",
-              "__Season__synopsis": null,
-              "__Season__synopsis_short": null,
-              "__Season__title": "GOT Season 2",
-              "__Season__title_short": "GOT S02",
-              "__Season__title_sort": null,
-              "__Season__number_of_episodes": null,
-              "__Season__release_date": "2012-04-01",
-              "__Season__season_number": 2
-            },
-            "position": 5
-          },
-          {
-            "object": {
-              "__typename": "SkylarkSet",
-              "_config": {
-                "primary_field": "title",
-                "colour": "#000000",
-                "display_name": "Setˢˡ"
-              },
-              "_meta": {
-                "available_languages": ["en-GB", "pt-PT"],
-                "language_data": { "language": "en-GB", "version": 1 },
-                "global_data": { "version": 2 }
-              },
-              "uid": "01GXZP40H07JY6YGNDEYHF5ENW",
-              "__SkylarkSet__slug": "discover-collection",
-              "external_id": null,
-              "__SkylarkSet__type": "COLLECTION",
-              "__SkylarkSet__title": "Discover Collection",
-              "__SkylarkSet__title_short": "Discover",
-              "__SkylarkSet__title_sort": null,
-              "__SkylarkSet__synopsis": null,
-              "__SkylarkSet__synopsis_short": null,
-              "__SkylarkSet__release_date": null,
-              "__SkylarkSet__description": null
-            },
-            "position": 6
+            "uid": "01H38TVVC7QPYEZC17K02Z97TH",
+            "external_id": "reckauU2wr4Jmo3BD",
+            "slug": null,
+            "title": "TopOfHomepage.png",
+            "description": null,
+            "type": "MAIN",
+            "url": "https://media.showcase.skylarkplatform.com/skylarkimages/mt3lb55zorcg7mu3mn62gzr5ne/01H38TVVC7QPYEZC17K02Z97TH/01H38TVW91KRH5C8A2Y4B2PK9P",
+            "file_name": null,
+            "content_type": "image/png"
           }
         ]
       }

--- a/src/__tests__/fixtures/skylark/queries/getObjectContent/homepage.json
+++ b/src/__tests__/fixtures/skylark/queries/getObjectContent/homepage.json
@@ -1,0 +1,206 @@
+{
+  "data": {
+    "getObjectContent": {
+      "__typename": "SkylarkSet",
+      "content": {
+        "next_token": null,
+        "objects": [
+          {
+            "object": {
+              "__typename": "SkylarkSet",
+              "_config": {
+                "primary_field": "title",
+                "colour": "#000000",
+                "display_name": "Setˢˡ"
+              },
+              "_meta": {
+                "available_languages": ["en-GB", "pt-PT"],
+                "language_data": {
+                  "language": "en-GB",
+                  "version": 1
+                },
+                "global_data": {
+                  "version": 2
+                }
+              },
+              "uid": "01H38V02XW6830845P73PJRHM1",
+              "__SkylarkSet__slug": "media-reference-home-page-hero",
+              "external_id": "streamtv_home_page_slider",
+              "__SkylarkSet__type": "SLIDER",
+              "__SkylarkSet__title": "Home page hero",
+              "__SkylarkSet__title_short": null,
+              "__SkylarkSet__title_sort": null,
+              "__SkylarkSet__synopsis": null,
+              "__SkylarkSet__synopsis_short": null,
+              "__SkylarkSet__release_date": null,
+              "__SkylarkSet__description": null
+            },
+            "position": 1
+          },
+          {
+            "object": {
+              "__typename": "SkylarkSet",
+              "_config": {
+                "primary_field": "title",
+                "colour": "#000000",
+                "display_name": "Setˢˡ"
+              },
+              "_meta": {
+                "available_languages": ["en-GB", "pt-PT"],
+                "language_data": {
+                  "language": "en-GB",
+                  "version": 1
+                },
+                "global_data": {
+                  "version": 2
+                }
+              },
+              "uid": "01H38TZWS0EEJJ34EZ4TS0VZ4S",
+              "__SkylarkSet__slug": "spotlight-movies",
+              "external_id": "streamtv_spotlight_movies",
+              "__SkylarkSet__type": "RAIL_MOVIE",
+              "__SkylarkSet__title": "Spotlight movies",
+              "__SkylarkSet__title_short": "Latest releases",
+              "__SkylarkSet__title_sort": null,
+              "__SkylarkSet__synopsis": null,
+              "__SkylarkSet__synopsis_short": null,
+              "__SkylarkSet__release_date": null,
+              "__SkylarkSet__description": null
+            },
+            "position": 2
+          },
+          {
+            "object": {
+              "__typename": "SkylarkSet",
+              "_config": {
+                "primary_field": "title",
+                "colour": "#000000",
+                "display_name": "Setˢˡ"
+              },
+              "_meta": {
+                "available_languages": ["en-GB", "pt-PT"],
+                "language_data": {
+                  "language": "en-GB",
+                  "version": 1
+                },
+                "global_data": {
+                  "version": 2
+                }
+              },
+              "uid": "01H38TZS24125D2V39YHR67WB2",
+              "__SkylarkSet__slug": "new-tv-releases",
+              "external_id": "streamtv_new_tv_releases",
+              "__SkylarkSet__type": "RAIL",
+              "__SkylarkSet__title": "New TV Releases",
+              "__SkylarkSet__title_short": "Premium TV",
+              "__SkylarkSet__title_sort": null,
+              "__SkylarkSet__synopsis": null,
+              "__SkylarkSet__synopsis_short": null,
+              "__SkylarkSet__release_date": null,
+              "__SkylarkSet__description": null
+            },
+            "position": 3
+          },
+          {
+            "object": {
+              "__typename": "Season",
+              "_config": {
+                "primary_field": "title",
+                "colour": "#9C27B0",
+                "display_name": "Season"
+              },
+              "_meta": {
+                "available_languages": ["en-GB", "pt-PT"],
+                "language_data": {
+                  "language": "en-GB",
+                  "version": 1
+                },
+                "global_data": {
+                  "version": 2
+                }
+              },
+              "uid": "01H38TY6XT5N73JT8J8Q5JQH62",
+              "external_id": "recNWXkYGdriyverR",
+              "__Season__slug": "got-s01",
+              "__Season__synopsis": "In the mythical continent of Westeros, several powerful families fight for control of the Seven Kingdoms. As conflict erupts in the kingdoms of men, an ancient enemy rises once again to threaten them all. Meanwhile, the last heirs of a recently usurped dynasty plot to take back their homeland from across the Narrow Sea.",
+              "__Season__synopsis_short": null,
+              "__Season__title": "GOT Season 1",
+              "__Season__title_short": "GOT S01",
+              "__Season__title_sort": null,
+              "__Season__number_of_episodes": null,
+              "__Season__release_date": "2011-10-17",
+              "__Season__season_number": 1,
+              "__Season__year_of_release": null
+            },
+            "position": 4
+          },
+          {
+            "object": {
+              "__typename": "Season",
+              "_config": {
+                "primary_field": "title",
+                "colour": "#9C27B0",
+                "display_name": "Season"
+              },
+              "_meta": {
+                "available_languages": ["en-GB", "pt-PT"],
+                "language_data": {
+                  "language": "en-GB",
+                  "version": 1
+                },
+                "global_data": {
+                  "version": 2
+                }
+              },
+              "uid": "01H38TY6JZCCEN9B10SKGJ299K",
+              "external_id": "rec6brp07XJZ5iFla",
+              "__Season__slug": "got-s02",
+              "__Season__synopsis": null,
+              "__Season__synopsis_short": null,
+              "__Season__title": "GOT Season 2",
+              "__Season__title_short": "GOT S02",
+              "__Season__title_sort": null,
+              "__Season__number_of_episodes": null,
+              "__Season__release_date": "2012-04-23",
+              "__Season__season_number": 2,
+              "__Season__year_of_release": null
+            },
+            "position": 5
+          },
+          {
+            "object": {
+              "__typename": "SkylarkSet",
+              "_config": {
+                "primary_field": "title",
+                "colour": "#000000",
+                "display_name": "Setˢˡ"
+              },
+              "_meta": {
+                "available_languages": ["en-GB", "pt-PT"],
+                "language_data": {
+                  "language": "en-GB",
+                  "version": 1
+                },
+                "global_data": {
+                  "version": 2
+                }
+              },
+              "uid": "01H38V17743ZH83NRWJFYFKVQ3",
+              "__SkylarkSet__slug": "discover-collection",
+              "external_id": "streamtv_discover_collection",
+              "__SkylarkSet__type": "RAIL_PORTRAIT",
+              "__SkylarkSet__title": "Discover",
+              "__SkylarkSet__title_short": "Discover",
+              "__SkylarkSet__title_sort": null,
+              "__SkylarkSet__synopsis": null,
+              "__SkylarkSet__synopsis_short": null,
+              "__SkylarkSet__release_date": null,
+              "__SkylarkSet__description": null
+            },
+            "position": 6
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/__tests__/fixtures/skylark/queries/getObjectRelationships/homepage.json
+++ b/src/__tests__/fixtures/skylark/queries/getObjectRelationships/homepage.json
@@ -1,6 +1,10 @@
 {
   "data": {
     "getObjectRelationships": {
+      "call_to_actions": {
+        "next_token": null,
+        "objects": []
+      },
       "credits": {
         "next_token": null,
         "objects": []
@@ -17,100 +21,87 @@
         "next_token": null,
         "objects": []
       },
-      "call_to_actions": {
-        "next_token": null,
-        "objects": []
-      },
       "images": {
         "next_token": null,
         "objects": [
           {
-            "uid": "01GZD84AX87E7EYQC9S4NM8CM8",
-            "__typename": "SkylarkImage",
-            "external_id": "reckauU2wr4Jmo3BD",
-            "slug": null,
-            "title": "TopOfHomepage.png",
-            "description": null,
-            "type": "MAIN",
-            "url": "https://media.showcase.skylarkplatform.com/skylarkimages/qlczc5jdljaj5areqh2lq3d27q/01GZD84AX87E7EYQC9S4NM8CM8/01GZD8ACSKP2JPHNJ3AE3201HD",
-            "external_url": null,
-            "upload_url": "https://obj-reg-storage-showcase-eu-west-1-storage.s3.amazonaws.com/media/skylarkimages/qlczc5jdljaj5areqh2lq3d27q/01GZD84AX87E7EYQC9S4NM8CM8/01GZDZGJ725BKAEDWAK26VT481.png?AWSAccessKeyId=ASIAQ425ZTI763AKLJXP&Signature=0GdyLqjMrezDvz5o11Kt66dHjpg%3D&content-type=image%2Fpng&x-amz-meta-account_id=qlczc5jdljaj5areqh2lq3d27q&x-amz-meta-uid=01GZD84AX87E7EYQC9S4NM8CM8&x-amz-security-token=IQoJb3JpZ2luX2VjELL%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCWV1LXdlc3QtMSJIMEYCIQCVkaKuFtutInEQ29gGKWf7cH0hz4ZdHxm0vP7PFLzRfgIhAPZlKarR8RG53DL3b1FCkPvZuvIsdqgQddJmowBLNbalKrADCLv%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEQABoMMDYxOTM2ODY3OTAzIgwaP03AEC0Fn%2FXJAkUqhAMDtwE2f6upkVtborzhpfCfkZRhrIhPxk5cFHMaP2AiuscMtNmRKjHbko4VDAeY4zMl%2BnpWM%2BAgJNTdQBCucpkp%2BoQnAI8vSW5ftwyxFYLGNV3EuM9N3JTOgY9qCsvitrG8wZdqovzJw0bT%2FyEedhutt9vKSD79dPShpyJsZMy2xzeCN8ECghs95v7oBZWoTDaTT133ZS7hfyINTXGFPW8kIAOjx5xwCwvmka37F%2Fa81kWngIVPB3UzOJoORIgq8aU4kpGblVJEYgWktTFC2tNi08p9B5hXS1j89RTAtvwtw%2BKwWRX%2FMrsTQctprtfbiWNl62I9ALiGVHbuDn4lFRm5cniI%2BEZpX17GAgCmOlaOWTbCsKmLkM%2BuG6Q56ZtHIs6U98JJb5ZnV01jMz%2FoN2w6g%2BGyBJDINmpsuqOFb7iu1XN2UQ1Cj5mcG%2Bnz2%2B3f2%2BghHlGLsnby34nHiEp2og3FPsB2SMeymBNfI3t8cjlJMarFqSuIq3W%2FBb0LsxI2vK15sqthMLnCw6IGOpwBitOBkDV9dy8l%2F%2Bk3iMGTYTEnPt9ZVLLrSNhFPIyWjrJ9CH1f%2BUsKDrkeJkSbh11eP3HlScI7mhMBJq2%2Bv%2Ben3fYgoLmMzM6R7MrkSfpxT9BRMXe1oHlTtFoERZU%2FUFULVDqDLAyD1WFZjFEIhyng9H9Av%2Fjk6PO35GJ%2FZzbCA1LNJn1tZWYabx7tGniAiIg8gy%2BkukPTv4k4ZmNe&Expires=1683026294",
-            "download_from_url": "https://v5.airtableusercontent.com/v1/16/16/1683007200000/ly3ABsSP555bq-Tervkc2w/afGMUAU1nz5tUWpiENiRlVWAn0Kx4Uxdbn452TttIk0hLj9bqUz0ANXk3Qe_-BrQBV9vuFUUBOZ29A2BJxJSXaG76LeO4WGj_WC5q-CAlrA/JPld6SNpgFZcCfX50RdqqgLXq-BZpdfAF4tOzyABx90",
-            "file_name": null,
-            "content_type": "image/png",
-            "_config": {
-              "primary_field": "title",
-              "colour": "#607d8b",
-              "display_name": "Imageˢˡ"
-            },
-            "_meta": {
-              "available_languages": ["en-GB"],
-              "language_data": {
-                "language": "en-GB",
-                "version": 2
-              },
-              "global_data": {
-                "version": 2
-              }
-            }
-          },
-          {
-            "uid": "01GZD84B0K3MP5VBVGN73PAB9N",
+            "uid": "01H38TVV5GAN2RHTPBVZC2C3BG",
             "__typename": "SkylarkImage",
             "external_id": "recBiJpHfAYK1sPiI",
             "slug": null,
             "title": "HomepageAfterCarousel.png",
             "description": null,
             "type": "MAIN",
-            "url": "https://media.showcase.skylarkplatform.com/skylarkimages/qlczc5jdljaj5areqh2lq3d27q/01GZD84B0K3MP5VBVGN73PAB9N/01GZD8AS5BDKAFT75ED87607CP",
-            "external_url": null,
-            "upload_url": "https://obj-reg-storage-showcase-eu-west-1-storage.s3.amazonaws.com/media/skylarkimages/qlczc5jdljaj5areqh2lq3d27q/01GZD84B0K3MP5VBVGN73PAB9N/01GZDZGJ7544WW0XYE27PT7P88.png?AWSAccessKeyId=ASIAQ425ZTI7RAO5BY4I&Signature=CucjR3jxLGIvY2%2BhcIN4juMo9V4%3D&content-type=image%2Fpng&x-amz-meta-account_id=qlczc5jdljaj5areqh2lq3d27q&x-amz-meta-uid=01GZD84B0K3MP5VBVGN73PAB9N&x-amz-security-token=IQoJb3JpZ2luX2VjELL%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCWV1LXdlc3QtMSJGMEQCICGEczas47IbeFTeh%2Bvan%2FxUzDXd8v70pt43sAUlnhSWAiAFMf8Tx9ZhlNPbsf803%2FnKa%2FknfFetK6e00rxGAMChHyqwAwi7%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F8BEAAaDDA2MTkzNjg2NzkwMyIM9DNa82yPjilwguy4KoQDfKHrNggYtc91JNBlh22Z%2FHTFqUKy3ZhEK61IgIH7tWXMjzMhBMhTcEvuyur7L6y40QSaHtDdBKiWfdznfVWJTjhOCO4Ae87rRAuOBWZdrgCJl8HfEHUwi3ICq%2BZOxCueGIrzErfN4mOyPTF1ylYlOhm%2BFqOjmZdrDeRLGNBUwOcnfWJUBrjaPXDB0v7yi2EC8KwfSmNEpVGhbn5cvymKJa9pxk8WiRd415uaIvnMEBcgyOAv%2F2Qf1jCpyEhQitw9BTomTSE74D82fclCVBniUS3wynxg5g3v3hUMR5lVvCzkWU%2BFnbu9IzNhDK3FXB0bgRoAmRfxJpNen7BpBfoXMoRyWNNADHZI8%2BZqXARElZqO9XuYKQzPyB7IM25efcJUzdAJAvhVISwfW58BgUwdKmp9O5UGnzPmCcOcVLM7X%2FoADosnhW8LyrT77ApUaOTMt9NIkSLsjJUY4dZKbKif6nvwk3KKVoS067Z5Vg%2FkDd1MVGbJ94gpjeYo49mtd8vj1gKs1zDVv8OiBjqeARZ%2FrLCiF9WyLnk7ohCOTNWJLv4zIs%2Bde%2FAfEUaVYeIeKgipnYtGNwL3gQXJuUDYviOSR8vQK4D8pv4F15xj3TriC%2BrB0Yi9fi191rfFYoJ1qzcBvF2CU7ifTlaHyvjg5c4rS7ihsUzryA5GpOin4c0StWonoMSE9cHI4pzTMtJ4iOonrwvADVRlaZUc9D%2BIDoOC3SP2qdNUS5lOWDpX&Expires=1683026294",
-            "download_from_url": "https://v5.airtableusercontent.com/v1/16/16/1683007200000/iy1TJImwAFPCEAmYjM0oyg/pYAQ0GGpa_knjCoiC7-AgFyONPLwXgN-fMYR3f7Ynlzw82rv4tBomlVqis2mUPzdXfJgVLePTYr_VeMn5qnOuUsW4MjrLsZj0QjorIIiQwGJVGBprSboyCXuf8oXgoHp/7srRVEpd1gflEnRfxS4RTSdortI2X88y4yVoLpf5DRQ",
+            "url": "https://media.showcase.skylarkplatform.com/skylarkimages/mt3lb55zorcg7mu3mn62gzr5ne/01H38TVV5GAN2RHTPBVZC2C3BG/01H38TVW496NC3SKYDNSWK6PJC",
             "file_name": null,
             "content_type": "image/png",
             "_config": {
               "primary_field": "title",
-              "colour": "#607d8b",
+              "colour": "#607D8B",
               "display_name": "Imageˢˡ"
             },
             "_meta": {
               "available_languages": ["en-GB"],
               "language_data": {
                 "language": "en-GB",
-                "version": 2
+                "version": 1
               },
               "global_data": {
-                "version": 2
+                "version": 1
               }
             }
           },
           {
-            "uid": "01GZD84DAPEH5S2018DPT1PE4K",
+            "uid": "01H38TVFRWJ9MKCS2T70BD0Q8C",
             "__typename": "SkylarkImage",
             "external_id": "recgkAKiElyJeSpvy",
             "slug": null,
             "title": "StreamTVLoadingScreen.png",
             "description": null,
             "type": "MAIN",
-            "url": "https://media.showcase.skylarkplatform.com/skylarkimages/qlczc5jdljaj5areqh2lq3d27q/01GZD84DAPEH5S2018DPT1PE4K/01GZD8AAN0K4053MPZ6B2ANBP4",
-            "external_url": null,
-            "upload_url": "https://obj-reg-storage-showcase-eu-west-1-storage.s3.amazonaws.com/media/skylarkimages/qlczc5jdljaj5areqh2lq3d27q/01GZD84DAPEH5S2018DPT1PE4K/01GZDZGJ7E7J7R4R7GWN66AHG1.png?AWSAccessKeyId=ASIAQ425ZTI7XUGD36EK&Signature=QZ7C9IIRmDpuEQ9P9n%2B5Xa5CmwQ%3D&content-type=image%2Fpng&x-amz-meta-account_id=qlczc5jdljaj5areqh2lq3d27q&x-amz-meta-uid=01GZD84DAPEH5S2018DPT1PE4K&x-amz-security-token=IQoJb3JpZ2luX2VjELL%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCWV1LXdlc3QtMSJHMEUCIQDMLckdKAXdp7bJZ4K88%2BMDVj4BMpWq7GBkUQvOhiRxQQIgaHslOsmTa10G6RBa%2Bke94bex9S9vr6YHqOS4QJOX0ukqsAMIu%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARAAGgwwNjE5MzY4Njc5MDMiDEiIJvikclLWgEDnBSqEA6Vf08pO%2F%2F4eX1xb6q9VM0VCrIoVdT%2F8JAdJVJoWBQcq2flYRQhv%2B5Xdr2S2s4afd7iXi7bLn61AfrcBbo8UO6nAJRrBMYwQTVkGA%2Fydy2xGkqReWUMgyTlDgqJxeEphKhZ7cMhSlb6msZVmEt0g1C8LnT%2Fuu8K%2BUq%2FQDFmnZtU2X%2Bw%2BINrDbHtkT0ylZEyzqACHBxFEc6sPbrBbePupdiPQpzQ%2ByWY4smxf3MCctBtJ%2FstW125TFx%2BoWNylQdy%2Bppwg%2BUHLSg0ZpZhzS%2BWsf0RMnKgubYZmAP%2F83dTO7NP1%2FrmQrfDpwB9%2B%2BBuOtExsSyZjG6KmO3PLJIO94zV2eWJUYt%2F4zcsmzIO8jML69psDgg%2B5JljhiGBDLsS%2BafKg4rvqFNpoWae3y7jkzvVS%2BuiEdHunhVi7N9tWoReNxxHGeF%2B7lI6wBU2c2V%2BMJRxPi03t3S2CZ4vMKPChWDzEwqt0i0vgQEdAw%2BmbTIU5Ab3wkEfTXMluX5OkL1nh5Eg6Gczx0Sgw1L%2FDogY6nQFJf0bgWrNjwAerR6vJ2Gp5k6dnTZqN6Rxf2O6sb91DUqifrCgwjon0GZgdej%2Bd85lHVxRWiVfaVA3FxsCNrmPlo7j8FRkS69yZ9eRz67O35ekBmpM6xusnM%2FGyBDyE6WjIo8gKApRdk%2B8ZeU40yPDr2pmf%2Fs%2FXWw%2FoV%2FMsaZHMgz%2BUeDnxppfA%2FLraWm5qLd%2BGJzG3F%2F6CHwKEaGLj&Expires=1683026294",
-            "download_from_url": "https://v5.airtableusercontent.com/v1/16/16/1683007200000/t1M2S7n_xRRzcnHaK3-YAw/IE4GjcGW--R7QzbdmPr8BNSgh-fCgAT5VxSQU6ZNp3OHoApVbvXPynSd5JuFKdd6aZ4MtqAookhOOoW9QyyqdroekTlQGrOJVsNbbeaZhJELsSOE9an1Fv-CcpneCP7g/mHquTGPAbZ2H_lj93ewxMa0HDvd_Ubh8okIJ8tHC3YI",
+            "url": "https://media.showcase.skylarkplatform.com/skylarkimages/mt3lb55zorcg7mu3mn62gzr5ne/01H38TVFRWJ9MKCS2T70BD0Q8C/01H38TVGNT7VY4V27Z3Y2PHYT0",
             "file_name": null,
             "content_type": "image/png",
             "_config": {
               "primary_field": "title",
-              "colour": "#607d8b",
+              "colour": "#607D8B",
               "display_name": "Imageˢˡ"
             },
             "_meta": {
               "available_languages": ["en-GB"],
               "language_data": {
                 "language": "en-GB",
-                "version": 2
+                "version": 1
               },
               "global_data": {
-                "version": 2
+                "version": 1
+              }
+            }
+          },
+          {
+            "uid": "01H38TVVC7QPYEZC17K02Z97TH",
+            "__typename": "SkylarkImage",
+            "external_id": "reckauU2wr4Jmo3BD",
+            "slug": null,
+            "title": "TopOfHomepage.png",
+            "description": null,
+            "type": "MAIN",
+            "url": "https://media.showcase.skylarkplatform.com/skylarkimages/mt3lb55zorcg7mu3mn62gzr5ne/01H38TVVC7QPYEZC17K02Z97TH/01H38TVW91KRH5C8A2Y4B2PK9P",
+            "file_name": null,
+            "content_type": "image/png",
+            "_config": {
+              "primary_field": "title",
+              "colour": "#607D8B",
+              "display_name": "Imageˢˡ"
+            },
+            "_meta": {
+              "available_languages": ["en-GB"],
+              "language_data": {
+                "language": "en-GB",
+                "version": 1
+              },
+              "global_data": {
+                "version": 1
               }
             }
           }

--- a/src/__tests__/fixtures/skylark/queries/search/homepage.json
+++ b/src/__tests__/fixtures/skylark/queries/search/homepage.json
@@ -16,7 +16,7 @@
             "language_data": { "language": "pt-PT", "version": 1 },
             "global_data": { "version": 2 }
           },
-          "uid": "01GXZP42M2RNMRQQ0EV3DRHCMW",
+          "uid": "01H38V1C0BNDWHNKSPGDKVXVS1",
           "__SkylarkSet__slug": "media-reference-homepage",
           "external_id": null,
           "__SkylarkSet__type": "PAGE",
@@ -54,7 +54,7 @@
             "language_data": { "language": "en-GB", "version": 1 },
             "global_data": { "version": 2 }
           },
-          "uid": "01GXZP42M2RNMRQQ0EV3DRHCMW",
+          "uid": "01H38V1C0BNDWHNKSPGDKVXVS1",
           "__SkylarkSet__slug": "media-reference-homepage",
           "external_id": "streamtv_homepage",
           "__SkylarkSet__type": "PAGE",

--- a/src/__tests__/mocks/handlers/getObjectHandlers.ts
+++ b/src/__tests__/mocks/handlers/getObjectHandlers.ts
@@ -3,7 +3,6 @@ import {
   GraphQLRequest,
   GraphQLVariables,
   ResponseComposition,
-  ResponseResolver,
   graphql,
 } from "msw";
 

--- a/src/__tests__/mocks/handlers/getObjectHandlers.ts
+++ b/src/__tests__/mocks/handlers/getObjectHandlers.ts
@@ -1,4 +1,11 @@
-import { graphql } from "msw";
+import {
+  GraphQLContext,
+  GraphQLRequest,
+  GraphQLVariables,
+  ResponseComposition,
+  ResponseResolver,
+  graphql,
+} from "msw";
 
 import GQLSkylarkGetAvailabilityQueryFixture from "src/__tests__/fixtures/skylark/queries/getObject/allDevicesAllCustomersAvailability.json";
 import GQLSkylarkGetMovieQueryFixture from "src/__tests__/fixtures/skylark/queries/getObject/fantasticMrFox_All_Availabilities.json";
@@ -8,11 +15,13 @@ import GQLSkylarkGetObjectGOTS01E01PTPTQueryFixture from "src/__tests__/fixtures
 import GQLSkylarkGetSeasonWithRelationshipsQueryFixture from "src/__tests__/fixtures/skylark/queries/getObject/gots04.json";
 import GQLSkylarkGetHomepageSetQueryFixture from "src/__tests__/fixtures/skylark/queries/getObject/homepage.json";
 import GQLSkylarkGetMovieQueryAvailabilityFixture from "src/__tests__/fixtures/skylark/queries/getObjectAvailability/fantasticMrFox_All_Availabilities.json";
+import GQLSkylarkGetHomepageSetContentQueryFixture from "src/__tests__/fixtures/skylark/queries/getObjectContent/homepage.json";
 import GQLSkylarkGetAvailabilityDimensionsQueryFixture from "src/__tests__/fixtures/skylark/queries/getObjectDimensions/allDevicesAllCustomersAvailability.json";
 import GQLSkylarkGetSeasonRelationshipsQueryFixture from "src/__tests__/fixtures/skylark/queries/getObjectRelationships/gots04relationships.json";
 import GQLSkylarkGetObjectsConfigFixture from "src/__tests__/fixtures/skylark/queries/getObjectsConfig/allObjectsConfig.json";
 import {
   createGetObjectAvailabilityQueryName,
+  createGetObjectContentQueryName,
   createGetObjectQueryName,
   createGetObjectRelationshipsQueryName,
 } from "src/lib/graphql/skylark/dynamicQueries";
@@ -101,14 +110,27 @@ export const getObjectHandlers = [
   ),
 ];
 
+const movieAvailabilityHandler = (
+  _: GraphQLRequest<GraphQLVariables>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  res: ResponseComposition<any>,
+  ctx: GraphQLContext<Record<string, unknown>>,
+) => {
+  return res(ctx.data(GQLSkylarkGetMovieQueryAvailabilityFixture.data));
+};
+
 export const getObjectAvailabilityHandlers = [
+  "Movie",
+  "Episode",
+  "Season",
+  "SkylarkSet",
+  "SkylarkImage",
+].map((objectType) =>
   graphql.query(
-    createGetObjectAvailabilityQueryName("Movie"),
-    (_, res, ctx) => {
-      return res(ctx.data(GQLSkylarkGetMovieQueryAvailabilityFixture.data));
-    },
+    createGetObjectAvailabilityQueryName(objectType),
+    movieAvailabilityHandler,
   ),
-];
+);
 
 export const getObjectAvailabilityDimensionHandlers = [
   graphql.query("GET_AVAILABILITY_DIMENSIONS", (_, res, ctx) => {
@@ -121,6 +143,15 @@ export const getObjectRelationshipsHandlers = [
     createGetObjectRelationshipsQueryName("Season"),
     (_, res, ctx) => {
       return res(ctx.data(GQLSkylarkGetSeasonRelationshipsQueryFixture.data));
+    },
+  ),
+];
+
+export const getObjectContentHandlers = [
+  graphql.query(
+    createGetObjectContentQueryName("SkylarkSet"),
+    (_, res, ctx) => {
+      return res(ctx.data(GQLSkylarkGetHomepageSetContentQueryFixture.data));
     },
   ),
 ];

--- a/src/__tests__/mocks/handlers/index.ts
+++ b/src/__tests__/mocks/handlers/index.ts
@@ -5,6 +5,7 @@ import { flatfileHandlers } from "./flatfile";
 import {
   getObjectAvailabilityDimensionHandlers,
   getObjectAvailabilityHandlers,
+  getObjectContentHandlers,
   getObjectHandlers,
   getObjectRelationshipsHandlers,
   getObjectsConfigHandlers,
@@ -20,6 +21,7 @@ export const handlers = [
   ...getObjectAvailabilityHandlers,
   ...getObjectAvailabilityDimensionHandlers,
   ...getObjectRelationshipsHandlers,
+  ...getObjectContentHandlers,
   ...createObjectHandlers,
   ...updateObjectHandlers,
   ...deleteObjectHandlers,

--- a/src/components/contentLibrary/contentLibrary.component.tsx
+++ b/src/components/contentLibrary/contentLibrary.component.tsx
@@ -29,8 +29,11 @@ const MINIMUM_SIZES = {
 export const ContentLibrary = () => {
   const {
     activePanelObject,
+    activePanelTab,
     setPanelObject,
+    setPanelTab,
     navigateToPreviousPanelObject,
+    navigateToForwardPanelObject,
     resetPanelObjectState,
   } = usePanelObjectState();
 
@@ -203,11 +206,14 @@ export const ContentLibrary = () => {
             <div className="w-full overflow-x-scroll">
               <Panel
                 object={activePanelObject}
+                tab={activePanelTab}
                 closePanel={closePanel}
                 isDraggedObject={!!draggedObject}
                 droppedObject={droppedObject}
                 setPanelObject={setPanelObject}
+                setTab={setPanelTab}
                 navigateToPreviousPanelObject={navigateToPreviousPanelObject}
+                navigateToForwardPanelObject={navigateToForwardPanelObject}
                 clearDroppedObject={() => setDroppedObject(undefined)}
               />
             </div>

--- a/src/components/contentLibrary/contentLibrary.test.tsx
+++ b/src/components/contentLibrary/contentLibrary.test.tsx
@@ -63,7 +63,7 @@ test("open metadata panel, check information and close", async () => {
   await waitFor(() =>
     expect(screen.queryByTestId("panel-header")).not.toBeInTheDocument(),
   );
-});
+}, 10000);
 
 test("displays the number of search results", async () => {
   render(<ContentLibrary />);

--- a/src/components/objectListing/objectListing.component.tsx
+++ b/src/components/objectListing/objectListing.component.tsx
@@ -76,13 +76,11 @@ export const ObjectList = ({
 
   // Sorts objects using the preference array above, any others are added to the end randomly
   const sortedHeaders = useMemo(() => {
-    const orderedKeysThatExist = properties.filter((property) =>
-      orderedKeys.includes(property),
-    );
+    const orderedKeysThatExist =
+      properties?.filter((property) => orderedKeys.includes(property)) || [];
 
-    const orderedProperties = properties.filter(
-      (property) => !orderedKeys.includes(property),
-    );
+    const orderedProperties =
+      properties?.filter((property) => !orderedKeys.includes(property)) || [];
 
     return [...hardcodedColumns, ...orderedKeysThatExist, ...orderedProperties];
   }, [properties]);

--- a/src/components/panel/panel.component.tsx
+++ b/src/components/panel/panel.component.tsx
@@ -231,7 +231,7 @@ export const Panel = ({
         },
       };
 
-      if (selectedTab !== PanelTab.Availability) {
+      if (objectMeta.hasContent && selectedTab !== PanelTab.Availability) {
         void prefetchGetObjectAvailability(prefetchArgs);
       }
       if (objectMeta.hasContent && selectedTab !== PanelTab.Content) {

--- a/src/components/panel/panel.component.tsx
+++ b/src/components/panel/panel.component.tsx
@@ -231,7 +231,7 @@ export const Panel = ({
         },
       };
 
-      if (objectMeta.hasContent && selectedTab !== PanelTab.Availability) {
+      if (objectMeta.hasAvailability && selectedTab !== PanelTab.Availability) {
         void prefetchGetObjectAvailability(prefetchArgs);
       }
       if (objectMeta.hasContent && selectedTab !== PanelTab.Content) {

--- a/src/components/panel/panel.component.tsx
+++ b/src/components/panel/panel.component.tsx
@@ -88,7 +88,7 @@ export const Panel = ({
   setTab: setSelectedTab,
   navigateToPreviousPanelObject,
   navigateToForwardPanelObject,
-  setPanelObject: setParentPanelObject,
+  setPanelObject,
 }: PanelProps) => {
   const [inEditMode, setEditMode] = useState(false);
   const [isTabDataPrefetched, setIsTabDataPrefetched] = useState(false);
@@ -171,48 +171,20 @@ export const Panel = ({
   );
 
   const resetPanelState = useCallback(
-    ({
-      resetIsTabDataPrefetched,
-      uidChanged,
-    }: {
-      resetIsTabDataPrefetched?: boolean;
-      uidChanged?: boolean;
-    }) => {
+    (resetIsTabDataPrefetched?: boolean) => {
       setEditMode(false);
       resetMetadataForm({});
 
-      if (resetIsTabDataPrefetched || uidChanged) {
+      if (resetIsTabDataPrefetched) {
         setIsTabDataPrefetched(false);
-      }
-
-      // Reset non-language dependent states only when uid changes
-      if (uidChanged) {
-        setContentObjects({
-          original: null,
-          updated: null,
-        });
-        setRelationshipObjects({
-          originalRelationshipObjects: null,
-          updatedRelationshipObjects: null,
-        });
       }
     },
     [resetMetadataForm],
   );
 
-  const setPanelObject = useCallback(
-    (newObject: SkylarkObjectIdentifier) => {
-      resetPanelState({
-        uidChanged: newObject.uid !== object.uid,
-      });
-      setParentPanelObject(newObject);
-    },
-    [resetPanelState, object.uid, setParentPanelObject],
-  );
-
   useEffect(() => {
     // Resets any edited data when the panel object changes
-    resetPanelState({ resetIsTabDataPrefetched: true });
+    resetPanelState(true);
   }, [uid, objectType, language, resetPanelState]);
 
   const queryClient = useQueryClient();

--- a/src/components/panel/panel.stories.tsx
+++ b/src/components/panel/panel.stories.tsx
@@ -17,7 +17,13 @@ export default {
 };
 
 const Template: ComponentStory<typeof Panel> = (args) => {
-  return <Panel {...args} closePanel={() => alert("Close clicked")} />;
+  return (
+    <Panel
+      {...args}
+      closePanel={() => alert("Close clicked")}
+      setPanelObject={() => ""}
+    />
+  );
 };
 
 export const Default = Template.bind({});

--- a/src/components/panel/panel.stories.tsx
+++ b/src/components/panel/panel.stories.tsx
@@ -2,8 +2,11 @@ import { ComponentStory } from "@storybook/react";
 import { userEvent, waitFor, within } from "@storybook/testing-library";
 import React from "react";
 
+import GQLSkylarkGetAvailabilityQueryFixture from "src/__tests__/fixtures/skylark/queries/getObject/allDevicesAllCustomersAvailability.json";
 import GQLSkylarkGetObjectQueryFixture from "src/__tests__/fixtures/skylark/queries/getObject/fantasticMrFox_All_Availabilities.json";
+import GQLSkylarkGetSeasonQueryFixture from "src/__tests__/fixtures/skylark/queries/getObject/gots04.json";
 import GQLSkylarkGetHomepageSetQueryFixture from "src/__tests__/fixtures/skylark/queries/getObject/homepage.json";
+import { PanelTab } from "src/hooks/usePanelObjectState";
 
 import { Panel } from "./panel.component";
 
@@ -24,6 +27,7 @@ Default.args = {
     objectType: "Movie",
     language: "",
   },
+  tab: PanelTab.Metadata,
 };
 
 export const PageView = Template.bind({});
@@ -34,24 +38,14 @@ PageView.args = {
     language: "",
   },
   isPage: true,
+  tab: PanelTab.Metadata,
 };
 
 export const Imagery = Template.bind({});
 Imagery.parameters = Default.parameters;
 Imagery.args = {
   ...Default.args,
-};
-Imagery.play = async ({ canvasElement }) => {
-  const canvas = within(canvasElement);
-
-  await canvas.findByText("System Metadata");
-
-  await canvas.findByRole("button", { name: /Imagery/i });
-  const tabButton = canvas.getByRole("button", { name: /Imagery/i });
-
-  await waitFor(async () => {
-    userEvent.click(tabButton);
-  });
+  tab: PanelTab.Imagery,
 };
 
 export const Content = Template.bind({});
@@ -62,18 +56,7 @@ Content.args = {
     uid: GQLSkylarkGetHomepageSetQueryFixture.data.getObject.uid,
     language: "",
   },
-};
-Content.play = async ({ canvasElement }) => {
-  const canvas = within(canvasElement);
-
-  await canvas.findByText("System Metadata");
-
-  await canvas.findByRole("button", { name: /Content/i });
-  const tabButton = canvas.getByRole("button", { name: /Content/i });
-
-  await waitFor(async () => {
-    userEvent.click(tabButton);
-  });
+  tab: PanelTab.Content,
 };
 
 export const ContentEditing = Template.bind({});
@@ -84,18 +67,10 @@ ContentEditing.args = {
     uid: GQLSkylarkGetHomepageSetQueryFixture.data.getObject.uid,
     language: "",
   },
+  tab: PanelTab.Content,
 };
 ContentEditing.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
-
-  await canvas.findByText("System Metadata");
-
-  await canvas.findByRole("button", { name: /Content/i });
-  const tabButton = canvas.getByRole("button", { name: /Content/i });
-
-  await waitFor(async () => {
-    userEvent.click(tabButton);
-  });
 
   await canvas.findByRole("button", { name: /Edit Content/i });
   const editButton = canvas.getByRole("button", { name: /Edit Content/i });
@@ -105,20 +80,33 @@ ContentEditing.play = async ({ canvasElement }) => {
   });
 };
 
+export const Relationships = Template.bind({});
+Relationships.parameters = Default.parameters;
+Relationships.args = {
+  ...Default.args,
+  object: {
+    objectType: "Season",
+    uid: GQLSkylarkGetSeasonQueryFixture.data.getObject.uid,
+    language: "",
+  },
+  tab: PanelTab.Relationships,
+};
+
 export const Availability = Template.bind({});
 Availability.parameters = Default.parameters;
 Availability.args = {
   ...Default.args,
+  tab: PanelTab.Availability,
 };
-Availability.play = async ({ canvasElement }) => {
-  const canvas = within(canvasElement);
 
-  await canvas.findByText("System Metadata");
-
-  await canvas.findByRole("button", { name: /Availability/i });
-  const imageryButton = canvas.getByRole("button", { name: /Availability/i });
-
-  await waitFor(async () => {
-    userEvent.click(imageryButton);
-  });
+export const AvailabilityDimensions = Template.bind({});
+AvailabilityDimensions.parameters = Default.parameters;
+AvailabilityDimensions.args = {
+  ...Default.args,
+  object: {
+    objectType: "Availability",
+    uid: GQLSkylarkGetAvailabilityQueryFixture.data.getObject.uid,
+    language: "",
+  },
+  tab: PanelTab.AvailabilityDimensions,
 };

--- a/src/components/panel/panelSections/panelAvailability.component.tsx
+++ b/src/components/panel/panelSections/panelAvailability.component.tsx
@@ -256,7 +256,7 @@ export const PanelAvailability = (props: PanelAvailabilityProps) => {
                     <div
                       key={obj.uid}
                       className={clsx(
-                        "my-2 max-w-xl border border-l-4 py-4 px-4",
+                        "my-4 max-w-xl border border-l-4 py-4 px-4",
                         status === AvailabilityStatus.Active &&
                           "border-l-success",
                         status === AvailabilityStatus.Expired &&
@@ -335,8 +335,8 @@ export const PanelAvailability = (props: PanelAvailabilityProps) => {
         isLoading={isLoading || hasNextPage}
         loadMore={() => fetchNextPage()}
       >
-        <Skeleton className="mb-2 h-52 w-full max-w-xl" />
-        <Skeleton className="mb-2 h-52 w-full max-w-xl" />
+        <Skeleton className="mb-4 h-52 w-full max-w-xl" />
+        <Skeleton className="mb-4 h-52 w-full max-w-xl" />
       </PanelLoading>
       <DisplayGraphQLQuery
         label="Get Object Availability"

--- a/src/components/panel/panelSections/panelContent.component.tsx
+++ b/src/components/panel/panelSections/panelContent.component.tsx
@@ -4,11 +4,14 @@ import { useEffect, useState } from "react";
 
 import { ObjectIdentifierCard } from "src/components/objectIdentifierCard";
 import { PanelDropZone } from "src/components/panel/panelDropZone/panelDropZone.component";
+import { PanelLoading } from "src/components/panel/panelLoading";
 import {
   PanelEmptyDataText,
   PanelSectionTitle,
   PanelSeparator,
 } from "src/components/panel/panelTypography";
+import { Skeleton } from "src/components/skeleton";
+import { useGetObjectContent } from "src/hooks/useGetObjectContent";
 import {
   ParsedSkylarkObjectContentObject,
   AddedSkylarkObjectContentObject,
@@ -18,11 +21,13 @@ import {
 
 import { PanelSectionLayout } from "./panelSectionLayout.component";
 
-interface PanelContentProps {
+interface PanelContentProps extends SkylarkObjectIdentifier {
   isPage?: boolean;
-  objects: AddedSkylarkObjectContentObject[];
-  objectType: string;
-  onReorder: (objs: ParsedSkylarkObjectContentObject[]) => void;
+  objects: AddedSkylarkObjectContentObject[] | null;
+  setContentObjects: (contentObjects: {
+    original: ParsedSkylarkObjectContentObject[] | null;
+    updated: AddedSkylarkObjectContentObject[] | null;
+  }) => void;
   inEditMode?: boolean;
   showDropZone?: boolean;
   setPanelObject: (o: SkylarkObjectIdentifier) => void;
@@ -100,31 +105,61 @@ export const PanelContent = ({
   objects,
   inEditMode,
   showDropZone,
-  onReorder,
+  objectType,
+  uid,
+  language,
+  setContentObjects,
   setPanelObject,
 }: PanelContentProps) => {
+  const { data, isLoading, hasNextPage, fetchNextPage } = useGetObjectContent(
+    objectType,
+    uid,
+    { language },
+  );
+
+  console.log({ data });
+
+  useEffect(() => {
+    if (!inEditMode && data) {
+      setContentObjects({
+        original: data,
+        updated: data,
+      });
+    }
+  }, [data, inEditMode, setContentObjects]);
+
+  const onReorder = (updated: AddedSkylarkObjectContentObject[]) =>
+    setContentObjects({
+      original: data,
+      updated,
+    });
+
   const removeItem = (uid: string) => {
-    const filtered = objects.filter(({ object }) => uid !== object.uid);
-    onReorder(filtered);
+    if (objects) {
+      const filtered = objects.filter(({ object }) => uid !== object.uid);
+      onReorder(filtered);
+    }
   };
 
   const handleManualOrderChange = (
     currentIndex: number,
     updatedPosition: number,
   ) => {
-    const updatedIndex = updatedPosition - 1;
-    const realUpdatedIndex =
-      updatedIndex <= 0
-        ? 0
-        : updatedIndex >= objects.length
-        ? objects.length - 1
-        : updatedIndex;
-    const updatedObjects = [...objects];
+    if (objects) {
+      const updatedIndex = updatedPosition - 1;
+      const realUpdatedIndex =
+        updatedIndex <= 0
+          ? 0
+          : updatedIndex >= objects.length
+          ? objects.length - 1
+          : updatedIndex;
+      const updatedObjects = [...objects];
 
-    const objToMove = updatedObjects.splice(currentIndex, 1)[0];
-    updatedObjects.splice(realUpdatedIndex, 0, objToMove);
+      const objToMove = updatedObjects.splice(currentIndex, 1)[0];
+      updatedObjects.splice(realUpdatedIndex, 0, objToMove);
 
-    onReorder(updatedObjects);
+      onReorder(updatedObjects);
+    }
   };
 
   if (showDropZone) {
@@ -137,76 +172,89 @@ export const PanelContent = ({
       isPage={isPage}
     >
       <PanelSectionTitle text="Content" id="content-panel-title" />
-      <Reorder.Group
-        axis="y"
-        values={objects}
-        onReorder={onReorder}
-        data-testid="panel-content-items"
-        className="flex-grow"
-      >
-        {objects?.length === 0 && <PanelEmptyDataText />}
-        {objects.map((item, index) => {
-          const { object, config, meta, position, isNewObject } = item;
+      {objects && (
+        <Reorder.Group
+          axis="y"
+          values={objects}
+          onReorder={onReorder}
+          data-testid="panel-content-items"
+          className="flex-grow"
+        >
+          {objects?.length === 0 && <PanelEmptyDataText />}
+          {objects.map((item, index) => {
+            const { object, config, meta, position, isNewObject } = item;
 
-          return (
-            <Reorder.Item
-              key={`panel-content-item-${object.uid}`}
-              value={item}
-              data-testid={`panel-object-content-item-${index + 1}`}
-              data-cy={"panel-object-content-item"}
-              className={clsx(
-                "my-0 flex flex-col items-center justify-center",
-                inEditMode && "cursor-pointer",
-              )}
-              dragListener={inEditMode}
-            >
-              <ObjectIdentifierCard
-                object={
-                  {
-                    objectType: object.__typename,
-                    uid: object.uid,
-                    metadata: object,
-                    config,
-                    meta,
-                  } as ParsedSkylarkObject
-                }
-                onForwardClick={setPanelObject}
-                disableForwardClick={inEditMode}
-                disableDeleteClick={!inEditMode}
-                onDeleteClick={() => removeItem(object.uid)}
+            return (
+              <Reorder.Item
+                key={`panel-content-item-${object.uid}`}
+                value={item}
+                data-testid={`panel-object-content-item-${index + 1}`}
+                data-cy={"panel-object-content-item"}
+                className={clsx(
+                  "my-0 flex flex-col items-center justify-center",
+                  inEditMode && "cursor-pointer",
+                )}
+                dragListener={inEditMode}
               >
-                <div className="flex">
-                  {inEditMode && (
-                    <span
-                      className={clsx(
-                        "flex h-6 items-center justify-center px-0.5 text-manatee-400 transition-opacity",
-                        position === index + 1 || isNewObject
-                          ? "opacity-0"
-                          : "opacity-100",
-                      )}
-                    >
-                      {position}
-                    </span>
-                  )}
-                  <PanelContentItemOrderInput
-                    disabled={!inEditMode}
-                    position={index + 1}
-                    hasMoved={!!inEditMode && position !== index + 1}
-                    isNewObject={inEditMode && isNewObject}
-                    onBlur={(updatedPosition: number) =>
-                      handleManualOrderChange(index, updatedPosition)
-                    }
-                    maxPosition={objects.length}
-                  />
-                </div>
-              </ObjectIdentifierCard>
-              {index < objects.length - 1 && (
-                <PanelSeparator transparent={inEditMode} />
-              )}
-            </Reorder.Item>
-          );
-        })}
-      </Reorder.Group>
+                <ObjectIdentifierCard
+                  object={
+                    {
+                      objectType: object.__typename,
+                      uid: object.uid,
+                      metadata: object,
+                      config,
+                      meta,
+                    } as ParsedSkylarkObject
+                  }
+                  onForwardClick={setPanelObject}
+                  disableForwardClick={inEditMode}
+                  disableDeleteClick={!inEditMode}
+                  onDeleteClick={() => removeItem(object.uid)}
+                >
+                  <div className="flex">
+                    {inEditMode && (
+                      <span
+                        className={clsx(
+                          "flex h-6 items-center justify-center px-0.5 text-manatee-400 transition-opacity",
+                          position === index + 1 || isNewObject
+                            ? "opacity-0"
+                            : "opacity-100",
+                        )}
+                      >
+                        {position}
+                      </span>
+                    )}
+                    <PanelContentItemOrderInput
+                      disabled={!inEditMode}
+                      position={index + 1}
+                      hasMoved={!!inEditMode && position !== index + 1}
+                      isNewObject={inEditMode && isNewObject}
+                      onBlur={(updatedPosition: number) =>
+                        handleManualOrderChange(index, updatedPosition)
+                      }
+                      maxPosition={objects.length}
+                    />
+                  </div>
+                </ObjectIdentifierCard>
+                {index < objects.length - 1 && (
+                  <PanelSeparator transparent={inEditMode} />
+                )}
+              </Reorder.Item>
+            );
+          })}
+        </Reorder.Group>
+      )}
+      <PanelLoading
+        isLoading={isLoading || hasNextPage}
+        loadMore={() => fetchNextPage()}
+      >
+        {Array.from({ length: 6 }, (_, i) => (
+          <Skeleton
+            key={`content-skeleton-${i}`}
+            className="mb-2 h-12 w-full max-w-xl"
+          />
+        ))}
+      </PanelLoading>
       {inEditMode && !isPage && (
         <p className="w-full py-4 text-center text-sm text-manatee-600">
           {"Drag an object from the Content Library to add as content"}

--- a/src/components/panel/panelSections/panelContent.component.tsx
+++ b/src/components/panel/panelSections/panelContent.component.tsx
@@ -111,13 +111,11 @@ export const PanelContent = ({
   setContentObjects,
   setPanelObject,
 }: PanelContentProps) => {
-  const { data, isLoading, hasNextPage, fetchNextPage } = useGetObjectContent(
+  const { data, isLoading, hasNextPage } = useGetObjectContent(
     objectType,
     uid,
     { language },
   );
-
-  console.log({ data });
 
   useEffect(() => {
     if (!inEditMode && data) {
@@ -180,7 +178,7 @@ export const PanelContent = ({
           data-testid="panel-content-items"
           className="flex-grow"
         >
-          {objects?.length === 0 && <PanelEmptyDataText />}
+          {objects && objects?.length === 0 && <PanelEmptyDataText />}
           {objects.map((item, index) => {
             const { object, config, meta, position, isNewObject } = item;
 
@@ -244,14 +242,11 @@ export const PanelContent = ({
           })}
         </Reorder.Group>
       )}
-      <PanelLoading
-        isLoading={isLoading || hasNextPage}
-        loadMore={() => fetchNextPage()}
-      >
+      <PanelLoading isLoading={isLoading || hasNextPage}>
         {Array.from({ length: 6 }, (_, i) => (
           <Skeleton
             key={`content-skeleton-${i}`}
-            className="mb-2 h-12 w-full max-w-xl"
+            className="mb-2 h-11 w-full max-w-xl"
           />
         ))}
       </PanelLoading>

--- a/src/components/panel/panelSections/panelContent.component.tsx
+++ b/src/components/panel/panelSections/panelContent.component.tsx
@@ -190,7 +190,7 @@ export const PanelContent = ({
 
             return (
               <Reorder.Item
-                key={`panel-content-item-${object.uid}`}
+                key={`panel-${uid}-content-item-${object.uid}`}
                 value={item}
                 data-testid={`panel-object-content-item-${index + 1}`}
                 data-cy={"panel-object-content-item"}

--- a/src/components/panel/panelSections/panelContent.component.tsx
+++ b/src/components/panel/panelSections/panelContent.component.tsx
@@ -18,6 +18,7 @@ import {
   ParsedSkylarkObject,
   SkylarkObjectIdentifier,
 } from "src/interfaces/skylark";
+import { hasProperty } from "src/lib/utils";
 
 import { PanelSectionLayout } from "./panelSectionLayout.component";
 
@@ -102,7 +103,7 @@ export const PanelContentItemOrderInput = ({
 
 export const PanelContent = ({
   isPage,
-  objects,
+  objects: updatedObjects,
   inEditMode,
   showDropZone,
   objectType,
@@ -116,6 +117,8 @@ export const PanelContent = ({
     uid,
     { language },
   );
+
+  const objects = inEditMode ? updatedObjects : data;
 
   useEffect(() => {
     if (!inEditMode && data) {
@@ -182,7 +185,8 @@ export const PanelContent = ({
             <PanelEmptyDataText />
           )}
           {objects.map((item, index) => {
-            const { object, config, meta, position, isNewObject } = item;
+            const { object, config, meta, position } = item;
+            const isNewObject = hasProperty(item, "isNewObject");
 
             return (
               <Reorder.Item

--- a/src/components/panel/panelSections/panelContent.component.tsx
+++ b/src/components/panel/panelSections/panelContent.component.tsx
@@ -178,7 +178,9 @@ export const PanelContent = ({
           data-testid="panel-content-items"
           className="flex-grow"
         >
-          {objects && objects?.length === 0 && <PanelEmptyDataText />}
+          {!isLoading && objects && objects?.length === 0 && (
+            <PanelEmptyDataText />
+          )}
           {objects.map((item, index) => {
             const { object, config, meta, position, isNewObject } = item;
 

--- a/src/components/panel/panelSections/panelHeader.component.tsx
+++ b/src/components/panel/panelSections/panelHeader.component.tsx
@@ -16,6 +16,7 @@ import {
   MoreVertical,
   ArrowLeft,
   ExternalLink,
+  ArrowRight,
 } from "src/components/icons";
 import { LanguageSelect } from "src/components/inputs/select";
 import {
@@ -52,6 +53,7 @@ interface PanelHeaderProps {
   save: () => void;
   setLanguage: (l: string) => void;
   navigateToPreviousPanelObject?: () => void;
+  navigateToForwardPanelObject?: () => void;
 }
 
 const ADD_LANGUAGE_OPTION = "Create Translation";
@@ -75,6 +77,7 @@ export const PanelHeader = ({
   save,
   setLanguage,
   navigateToPreviousPanelObject,
+  navigateToForwardPanelObject,
 }: PanelHeaderProps) => {
   const title = getObjectDisplayName(object);
   const [showGraphQLModal, setGraphQLModalOpen] = useState(false);
@@ -138,25 +141,32 @@ export const PanelHeader = ({
       <div className="flex flex-row pb-2">
         <div className="flex flex-grow items-center space-x-2">
           {!isPage && (
-            <Button
-              Icon={<ArrowLeft />}
-              variant="ghost"
-              disabled={!navigateToPreviousPanelObject || inEditMode}
-              onClick={navigateToPreviousPanelObject}
-              aria-label="Open Previous Object"
-            />
-          )}
-          {!isPage && (
-            <Button
-              Icon={<ExternalLink />}
-              variant="ghost"
-              href={
-                actualLanguage
-                  ? `/object/${objectType}/${objectUid}?language=${actualLanguage}`
-                  : `/object/${objectType}/${objectUid}`
-              }
-              newTab
-            />
+            <>
+              <Button
+                Icon={<ArrowLeft />}
+                variant="ghost"
+                disabled={!navigateToPreviousPanelObject || inEditMode}
+                onClick={navigateToPreviousPanelObject}
+                aria-label="Click to go back"
+              />
+              <Button
+                Icon={<ArrowRight />}
+                variant="ghost"
+                disabled={!navigateToForwardPanelObject || inEditMode}
+                onClick={navigateToForwardPanelObject}
+                aria-label="Click to go forward"
+              />
+              <Button
+                Icon={<ExternalLink />}
+                variant="ghost"
+                href={
+                  actualLanguage
+                    ? `/object/${objectType}/${objectUid}?language=${actualLanguage}`
+                    : `/object/${objectType}/${objectUid}`
+                }
+                newTab
+              />
+            </>
           )}
           <DropdownMenu options={objectMenuOptions} align="left">
             <DropdownMenuButton

--- a/src/components/panel/panelSections/panelMetadataAdditionalSections.tsx
+++ b/src/components/panel/panelSections/panelMetadataAdditionalSections.tsx
@@ -41,7 +41,7 @@ export const AdditionalImageMetadata = ({
     <div className="-mt-4">
       <PanelMetadataProperty
         property="Original Size"
-        value={size ? `${size?.h}x${size?.w}` : ""}
+        value={size ? `${size?.w}x${size?.h}` : ""}
       />
       <PanelMetadataProperty
         property="Rendered image"

--- a/src/components/panel/panelSections/panelRelationships.component.tsx
+++ b/src/components/panel/panelSections/panelRelationships.component.tsx
@@ -47,12 +47,16 @@ export const PanelRelationships = ({
   setPanelObject,
 }: PanelRelationshipsProps) => {
   const {
-    relationships,
+    relationships: serverRelationships,
     objectRelationships = [],
     isLoading,
     query,
     variables,
   } = useGetObjectRelationships(objectType, uid, { language });
+
+  const relationships = inEditMode
+    ? updatedRelationshipObjects
+    : serverRelationships;
 
   useEffect(() => {
     if (!inEditMode) {
@@ -64,19 +68,17 @@ export const PanelRelationships = ({
   }, [inEditMode, relationships, setRelationshipObjects]);
 
   const removeRelationshipObject = (removeUid: string, relationship: string) =>
-    updatedRelationshipObjects &&
+    relationships &&
     setRelationshipObjects({
-      updatedRelationshipObjects: updatedRelationshipObjects?.map(
-        (currentRelationship) => {
-          const { objects, relationshipName } = currentRelationship;
-          if (relationshipName === relationship) {
-            const filteredObjects = objects.filter(
-              (obj) => obj.uid !== removeUid,
-            );
-            return { ...currentRelationship, objects: filteredObjects };
-          } else return currentRelationship;
-        },
-      ),
+      updatedRelationshipObjects: relationships?.map((currentRelationship) => {
+        const { objects, relationshipName } = currentRelationship;
+        if (relationshipName === relationship) {
+          const filteredObjects = objects.filter(
+            (obj) => obj.uid !== removeUid,
+          );
+          return { ...currentRelationship, objects: filteredObjects };
+        } else return currentRelationship;
+      }),
       originalRelationshipObjects: relationships,
     });
 
@@ -87,7 +89,7 @@ export const PanelRelationships = ({
   const relationshipNames = objectRelationships.map(
     ({ relationshipName }) => relationshipName,
   );
-  const orderedRelationshipObjects = updatedRelationshipObjects?.sort(
+  const orderedRelationshipObjects = relationships?.sort(
     (a, b) =>
       relationshipNames.indexOf(a.relationshipName) -
       relationshipNames.indexOf(b.relationshipName),
@@ -106,7 +108,7 @@ export const PanelRelationships = ({
       isPage={isPage}
     >
       <div>
-        {updatedRelationshipObjects &&
+        {relationships &&
           orderedRelationshipObjects?.map((relationship) => {
             const { relationshipName, objects } = relationship;
             const isExpanded = expandedRelationships[relationshipName];
@@ -134,7 +136,7 @@ export const PanelRelationships = ({
 
                       const newUids =
                         relationshipObject &&
-                        relationships &&
+                        updatedRelationshipObjects &&
                         parseUpdatedRelationshipObjects(
                           relationshipObject,
                           updatedRelationshipObjects,

--- a/src/components/tabs/tabs.component.tsx
+++ b/src/components/tabs/tabs.component.tsx
@@ -1,10 +1,9 @@
 import clsx from "clsx";
-import { Dispatch, SetStateAction } from "react";
 
 interface TabProps {
   tabs: string[];
   selectedTab: string;
-  onChange: Dispatch<SetStateAction<string>>;
+  onChange: (t: string) => void;
   disabled?: boolean;
 }
 

--- a/src/enums/graphql.ts
+++ b/src/enums/graphql.ts
@@ -7,6 +7,7 @@ export enum QueryKeys {
   GetObjectAvailability = "getObjectAvailability",
   GetObjectRelationships = "getObjectRelationships",
   GetObjectDimensions = "getObjectDimensions",
+  GetObjectContent = "getObjectContent",
 }
 
 export enum QueryErrorMessages {

--- a/src/hooks/useGetObject.ts
+++ b/src/hooks/useGetObject.ts
@@ -48,9 +48,8 @@ export const useGetObject = (
     error: objectMetaError,
     isError: isObjectMetaError,
   } = useSkylarkObjectOperations(objectType);
-  const { objects: contentObjects } = useAllObjectsMeta(false);
 
-  const query = createGetObjectQuery(objectMeta, contentObjects, !!language);
+  const query = createGetObjectQuery(objectMeta, !!language);
   const variables = { uid, language };
 
   const { data, error, ...rest } = useQuery<

--- a/src/hooks/useGetObjectAvailability.tsx
+++ b/src/hooks/useGetObjectAvailability.tsx
@@ -97,13 +97,15 @@ export const prefetchGetObjectAvailability = async ({
     uid: string;
   };
 }) => {
-  const { queryFn, queryKey } = generateQueryFunctionAndKey({
-    objectMeta,
-    objectType,
-    uid,
-    variables,
-  });
-  await queryClient.prefetchInfiniteQuery({ queryKey, queryFn });
+  if (objectMeta?.hasAvailability) {
+    const { queryFn, queryKey } = generateQueryFunctionAndKey({
+      objectMeta,
+      objectType,
+      uid,
+      variables,
+    });
+    await queryClient.prefetchInfiniteQuery({ queryKey, queryFn });
+  }
 };
 
 export const useGetObjectAvailability = (

--- a/src/hooks/useGetObjectContent.tsx
+++ b/src/hooks/useGetObjectContent.tsx
@@ -41,7 +41,7 @@ const generateQueryFunctionAndKey = ({
   variables,
 }: {
   objectMeta: SkylarkObjectMeta | null;
-  contentObjectsMeta: SkylarkObjectMeta[];
+  contentObjectsMeta: SkylarkObjectMeta[] | null;
   objectType: SkylarkObjectType;
   uid: string;
   variables: {
@@ -63,11 +63,12 @@ const generateQueryFunctionAndKey = ({
   const queryFn: QueryFunction<
     GQLSkylarkGetObjectContentResponse,
     QueryKey
-  > = async ({ pageParam: nextToken }) =>
-    skylarkRequest(query as RequestDocument, {
+  > = async ({ pageParam: nextToken }) => {
+    return skylarkRequest(query as RequestDocument, {
       ...variables,
       nextToken,
     });
+  };
 
   const queryKey: QueryKey = [
     ...createGetObjectContentKeyPrefix({
@@ -136,7 +137,7 @@ export const useGetObjectContent = (
     variables,
   });
 
-  const { data, ...rest } = useInfiniteQuery<
+  const { data, hasNextPage, fetchNextPage, ...rest } = useInfiniteQuery<
     GQLSkylarkGetObjectContentResponse,
     GQLSkylarkErrorResponse<GQLSkylarkGetObjectContentResponse>
   >({
@@ -146,6 +147,10 @@ export const useGetObjectContent = (
       lastPage.getObjectContent.content?.next_token || undefined,
     enabled: !!query,
   });
+
+  if (hasNextPage) {
+    fetchNextPage();
+  }
 
   const content = useMemo(() => {
     const contentObjects =
@@ -162,5 +167,6 @@ export const useGetObjectContent = (
     isLoading: rest.isLoading || !query,
     query,
     variables,
+    hasNextPage,
   };
 };

--- a/src/hooks/useGetObjectContent.tsx
+++ b/src/hooks/useGetObjectContent.tsx
@@ -4,7 +4,6 @@ import {
   QueryKey,
   useInfiniteQuery,
 } from "@tanstack/react-query";
-import dayjs from "dayjs";
 import { DocumentNode } from "graphql";
 import { RequestDocument } from "graphql-request";
 import { useMemo } from "react";
@@ -13,31 +12,36 @@ import { QueryKeys } from "src/enums/graphql";
 import {
   SkylarkObjectType,
   GQLSkylarkErrorResponse,
-  GQLSkylarkGetObjectAvailabilityResponse,
-  ParsedSkylarkObjectAvailabilityObject,
   SkylarkObjectMeta,
+  GQLSkylarkGetObjectContentResponse,
 } from "src/interfaces/skylark";
 import { skylarkRequest } from "src/lib/graphql/skylark/client";
-import { createGetObjectAvailabilityQuery } from "src/lib/graphql/skylark/dynamicQueries";
+import { createGetObjectContentQuery } from "src/lib/graphql/skylark/dynamicQueries";
+import { parseObjectContent } from "src/lib/skylark/parsers";
 
 import { GetObjectOptions } from "./useGetObject";
-import { useSkylarkObjectOperations } from "./useSkylarkObjectTypes";
+import {
+  useAllObjectsMeta,
+  useSkylarkObjectOperations,
+} from "./useSkylarkObjectTypes";
 
-export const createGetObjectAvailabilityKeyPrefix = ({
+export const createGetObjectContentKeyPrefix = ({
   objectType,
   uid,
 }: {
   objectType: string;
   uid: string;
-}) => [QueryKeys.GetObjectAvailability, { objectType, uid }];
+}) => [QueryKeys.GetObjectContent, { objectType, uid }];
 
 const generateQueryFunctionAndKey = ({
   objectMeta,
+  contentObjectsMeta,
   objectType,
   uid,
   variables,
 }: {
   objectMeta: SkylarkObjectMeta | null;
+  contentObjectsMeta: SkylarkObjectMeta[];
   objectType: SkylarkObjectType;
   uid: string;
   variables: {
@@ -46,17 +50,18 @@ const generateQueryFunctionAndKey = ({
     uid: string;
   };
 }): {
-  queryFn: QueryFunction<GQLSkylarkGetObjectAvailabilityResponse, QueryKey>;
+  queryFn: QueryFunction<GQLSkylarkGetObjectContentResponse, QueryKey>;
   queryKey: QueryKey;
   query: DocumentNode | null;
 } => {
-  const query = createGetObjectAvailabilityQuery(
+  const query = createGetObjectContentQuery(
     objectMeta,
+    contentObjectsMeta,
     !!variables.language,
   );
 
   const queryFn: QueryFunction<
-    GQLSkylarkGetObjectAvailabilityResponse,
+    GQLSkylarkGetObjectContentResponse,
     QueryKey
   > = async ({ pageParam: nextToken }) =>
     skylarkRequest(query as RequestDocument, {
@@ -65,7 +70,7 @@ const generateQueryFunctionAndKey = ({
     });
 
   const queryKey: QueryKey = [
-    ...createGetObjectAvailabilityKeyPrefix({
+    ...createGetObjectContentKeyPrefix({
       objectType,
       uid,
     }),
@@ -80,15 +85,17 @@ const generateQueryFunctionAndKey = ({
   };
 };
 
-export const prefetchGetObjectAvailability = async ({
+export const prefetchGetObjectContent = async ({
   queryClient,
   objectMeta,
+  contentObjectsMeta,
   objectType,
   uid,
   variables,
 }: {
   queryClient: QueryClient;
   objectMeta: SkylarkObjectMeta | null;
+  contentObjectsMeta: SkylarkObjectMeta[];
   objectType: SkylarkObjectType;
   uid: string;
   variables: {
@@ -99,6 +106,7 @@ export const prefetchGetObjectAvailability = async ({
 }) => {
   const { queryFn, queryKey } = generateQueryFunctionAndKey({
     objectMeta,
+    contentObjectsMeta,
     objectType,
     uid,
     variables,
@@ -106,7 +114,7 @@ export const prefetchGetObjectAvailability = async ({
   await queryClient.prefetchInfiniteQuery({ queryKey, queryFn });
 };
 
-export const useGetObjectAvailability = (
+export const useGetObjectContent = (
   objectType: SkylarkObjectType,
   uid: string,
   opts?: GetObjectOptions,
@@ -116,47 +124,41 @@ export const useGetObjectAvailability = (
   const { objectOperations: objectMeta } =
     useSkylarkObjectOperations(objectType);
 
+  const { objects: contentObjectsMeta } = useAllObjectsMeta(false);
+
   const variables = { uid, nextToken: "", language };
 
   const { queryFn, queryKey, query } = generateQueryFunctionAndKey({
     objectMeta,
+    contentObjectsMeta,
     objectType,
     uid,
     variables,
   });
 
   const { data, ...rest } = useInfiniteQuery<
-    GQLSkylarkGetObjectAvailabilityResponse,
-    GQLSkylarkErrorResponse<GQLSkylarkGetObjectAvailabilityResponse>
+    GQLSkylarkGetObjectContentResponse,
+    GQLSkylarkErrorResponse<GQLSkylarkGetObjectContentResponse>
   >({
     queryFn,
     queryKey,
     getNextPageParam: (lastPage): string | undefined =>
-      lastPage.getObjectAvailability.availability?.next_token || undefined,
+      lastPage.getObjectContent.content?.next_token || undefined,
+    enabled: !!query,
   });
 
-  const availability: ParsedSkylarkObjectAvailabilityObject[] | undefined =
-    useMemo(
-      () =>
-        data?.pages
-          ?.flatMap((page) => page.getObjectAvailability.availability.objects)
-          .map((object): ParsedSkylarkObjectAvailabilityObject => {
-            return {
-              ...object,
-              title: object.title || "",
-              slug: object.slug || "",
-              start: object.start || "",
-              end: object.end || "",
-              timezone: object.timezone || "",
-              dimensions: object.dimensions.objects,
-            };
-          }),
-      [data?.pages],
-    );
+  const content = useMemo(() => {
+    const contentObjects =
+      data?.pages?.flatMap((page) => page.getObjectContent.content.objects) ||
+      [];
+
+    const parsedContent = parseObjectContent({ objects: contentObjects });
+    return parsedContent;
+  }, [data?.pages]);
 
   return {
     ...rest,
-    data: availability,
+    data: content.objects,
     isLoading: rest.isLoading || !query,
     query,
     variables,

--- a/src/hooks/useGetObjectRelationships.ts
+++ b/src/hooks/useGetObjectRelationships.ts
@@ -25,10 +25,10 @@ import {
 } from "./useSkylarkObjectTypes";
 
 const getFieldsFromObjectType = (
-  objects: SkylarkObjectMeta[],
+  objects: SkylarkObjectMeta[] | null,
   objectType: string,
 ) => {
-  const object = objects.find(({ name }) => name === objectType);
+  const object = objects?.find(({ name }) => name === objectType);
   return object?.fields || [];
 };
 

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -74,7 +74,7 @@ export const useSearch = (queryString: string, filters: SearchFilters) => {
       ) || [];
 
     const parsedObjects = normalisedObjects.map((obj) => {
-      const objectMeta = searchableObjects.find(
+      const objectMeta = searchableObjects?.find(
         ({ name }) => name === obj.__typename,
       );
       return parseSkylarkObject(obj, objectMeta);

--- a/src/hooks/useSkylarkObjectTypes.ts
+++ b/src/hooks/useSkylarkObjectTypes.ts
@@ -96,18 +96,19 @@ export const useSkylarkObjectOperations = (objectType: SkylarkObjectType) => {
   }
 };
 
-export const useAllObjectsMeta = (searchable: boolean) => {
+export const useAllObjectsMeta = (searchableOnly?: boolean) => {
   const { data: schemaResponse, ...rest } = useSkylarkSchemaIntrospection();
 
-  const { objectTypes } = useSkylarkObjectTypes(searchable);
+  const { objectTypes } = useSkylarkObjectTypes(!!searchableOnly);
 
   const { objects, allFieldNames } = useMemo(() => {
     const objects =
       schemaResponse && objectTypes
         ? getAllObjectsMeta(schemaResponse, objectTypes)
-        : [];
+        : null;
+
     const allFieldNames = objects
-      .flatMap(({ fields }) => fields)
+      ?.flatMap(({ fields }) => fields)
       .map(({ name }) => name)
       .filter((name, index, self) => self.indexOf(name) === index);
 

--- a/src/hooks/useUpdateObjectContent.tsx
+++ b/src/hooks/useUpdateObjectContent.tsx
@@ -11,7 +11,7 @@ import { skylarkRequest } from "src/lib/graphql/skylark/client";
 import { createUpdateObjectContentMutation } from "src/lib/graphql/skylark/dynamicMutations";
 import { parseObjectContent } from "src/lib/skylark/parsers";
 
-import { createGetObjectKeyPrefix } from "./useGetObject";
+import { createGetObjectContentKeyPrefix } from "./useGetObjectContent";
 import {
   useAllObjectsMeta,
   useSkylarkObjectOperations,
@@ -20,14 +20,14 @@ import {
 export const useUpdateObjectContent = ({
   objectType,
   uid,
-  currentContentObjects,
+  originalContentObjects,
   updatedContentObjects,
   onSuccess,
 }: {
   objectType: SkylarkObjectType;
   uid: string;
-  currentContentObjects: ParsedSkylarkObjectContentObject[];
-  updatedContentObjects: ParsedSkylarkObjectContentObject[];
+  originalContentObjects: ParsedSkylarkObjectContentObject[] | null;
+  updatedContentObjects: ParsedSkylarkObjectContentObject[] | null;
   onSuccess: (updatedContent: ParsedSkylarkObjectContent) => void;
 }) => {
   const queryClient = useQueryClient();
@@ -36,7 +36,7 @@ export const useUpdateObjectContent = ({
 
   const updateObjectContentMutation = createUpdateObjectContentMutation(
     objectOperations,
-    currentContentObjects,
+    originalContentObjects,
     updatedContentObjects,
     objects,
   );
@@ -50,7 +50,7 @@ export const useUpdateObjectContent = ({
     },
     onSuccess: (data, { uid }) => {
       queryClient.invalidateQueries({
-        queryKey: createGetObjectKeyPrefix({ objectType, uid }),
+        queryKey: createGetObjectContentKeyPrefix({ objectType, uid }),
       });
       const parsedObjectContent = parseObjectContent(
         data.updateObjectContent.content,

--- a/src/interfaces/skylark/gqlObjects.ts
+++ b/src/interfaces/skylark/gqlObjects.ts
@@ -79,6 +79,7 @@ export interface SkylarkGraphQLObjectImage {
 }
 
 export interface SkylarkGraphQLObjectContent {
+  next_token?: NextToken;
   objects: {
     object: SkylarkGraphQLObject;
     position: number;

--- a/src/interfaces/skylark/responses.ts
+++ b/src/interfaces/skylark/responses.ts
@@ -31,6 +31,13 @@ export interface GQLSkylarkGetObjectResponse {
 export interface GQLSkylarkGetObjectRelationshipsResponse {
   getObjectRelationships: SkylarkGraphQLObject;
 }
+
+export interface GQLSkylarkGetObjectContentResponse {
+  getObjectContent: {
+    content: SkylarkGraphQLObjectContent;
+  };
+}
+
 export interface GQLSkylarkGetObjectAvailabilityResponse {
   getObjectAvailability: {
     availability: {

--- a/src/interfaces/skylark/responses.ts
+++ b/src/interfaces/skylark/responses.ts
@@ -64,7 +64,7 @@ export interface GQLSkylarkUpdateObjectMetadataResponse {
 
 export interface GQLSkylarkUpdateObjectContentResponse {
   updateObjectContent: {
-    content: SkylarkGraphQLObjectContent;
+    uid: string;
   };
 }
 

--- a/src/lib/graphql/skylark/dynamicMutations.test.ts
+++ b/src/lib/graphql/skylark/dynamicMutations.test.ts
@@ -1,7 +1,6 @@
 import {
   episodeObjectOperations,
   setObjectOperations,
-  movieObjectOperations,
 } from "src/__tests__/utils/objectOperations";
 import {
   AvailabilityStatus,
@@ -45,7 +44,7 @@ describe("createDeleteObjectMutation", () => {
 
 describe("createUpdateSetContentPositionMutation", () => {
   test("returns null when the object doesn't have an update operation", () => {
-    const got = createUpdateObjectContentMutation(null, [], [], []);
+    const got = createUpdateObjectContentMutation(null, [], []);
 
     expect(got).toBeNull();
   });
@@ -91,7 +90,6 @@ describe("createUpdateSetContentPositionMutation", () => {
       setObjectOperations,
       content,
       content,
-      [episodeObjectOperations, movieObjectOperations],
     );
 
     expect(got?.loc?.source.body).toContain(
@@ -142,7 +140,6 @@ describe("createUpdateSetContentPositionMutation", () => {
       setObjectOperations,
       content,
       updatedContent,
-      [episodeObjectOperations, movieObjectOperations],
     );
 
     expect(got?.loc?.source.body).toContain(
@@ -193,7 +190,6 @@ describe("createUpdateSetContentPositionMutation", () => {
       setObjectOperations,
       content,
       updatedContent,
-      [episodeObjectOperations, movieObjectOperations],
     );
 
     expect(got?.loc?.source.body).toContain(

--- a/src/lib/graphql/skylark/dynamicMutations.ts
+++ b/src/lib/graphql/skylark/dynamicMutations.ts
@@ -281,7 +281,6 @@ export const createUpdateObjectContentMutation = (
           },
         },
         uid: true,
-        ...generateContentsToReturn(object, contentTypesToRequest),
       },
     },
   };

--- a/src/lib/graphql/skylark/dynamicMutations.ts
+++ b/src/lib/graphql/skylark/dynamicMutations.ts
@@ -183,7 +183,6 @@ export const createUpdateObjectContentMutation = (
   object: SkylarkObjectMeta | null,
   originalContentObjects: ParsedSkylarkObjectContentObject[] | null,
   updatedContentObjects: ParsedSkylarkObjectContentObject[] | null,
-  contentTypesToRequest: SkylarkObjectMeta[],
 ) => {
   if (
     !object ||

--- a/src/lib/graphql/skylark/dynamicMutations.ts
+++ b/src/lib/graphql/skylark/dynamicMutations.ts
@@ -181,15 +181,20 @@ export const createUpdateObjectMetadataMutation = (
 
 export const createUpdateObjectContentMutation = (
   object: SkylarkObjectMeta | null,
-  currentContentObjects: ParsedSkylarkObjectContentObject[],
-  updatedContentObjects: ParsedSkylarkObjectContentObject[],
+  originalContentObjects: ParsedSkylarkObjectContentObject[] | null,
+  updatedContentObjects: ParsedSkylarkObjectContentObject[] | null,
   contentTypesToRequest: SkylarkObjectMeta[],
 ) => {
-  if (!object || !object.operations.update) {
+  if (
+    !object ||
+    !object.operations.update ||
+    !originalContentObjects ||
+    !updatedContentObjects
+  ) {
     return null;
   }
 
-  const currentContentObjectUids = currentContentObjects.map(
+  const originalContentObjectUids = originalContentObjects.map(
     ({ object }) => object.uid,
   );
   const updatedContentObjectUids = updatedContentObjects.map(
@@ -199,7 +204,7 @@ export const createUpdateObjectContentMutation = (
   const linkOrRepositionOperations = updatedContentObjects.map(
     ({ objectType, object: { uid } }, index): SetContentOperation => {
       const position = index + 1;
-      if (currentContentObjectUids.includes(uid)) {
+      if (originalContentObjectUids.includes(uid)) {
         return {
           operation: "reposition",
           objectType,
@@ -216,7 +221,7 @@ export const createUpdateObjectContentMutation = (
     },
   );
 
-  const deleteOperations = currentContentObjects
+  const deleteOperations = originalContentObjects
     .filter(({ object: { uid } }) => !updatedContentObjectUids.includes(uid))
     .map(({ objectType, object: { uid } }): SetContentOperation => {
       return {

--- a/src/lib/graphql/skylark/dynamicMutations.ts
+++ b/src/lib/graphql/skylark/dynamicMutations.ts
@@ -55,6 +55,9 @@ export const createDeleteObjectMutation = (
     };
   }
 
+  const returnFields =
+    object.name === BuiltInSkylarkObjectType.Availability ? {} : { uid: true };
+
   const mutation = {
     mutation: {
       __name: `DELETE_${object.name}`,
@@ -70,7 +73,7 @@ export const createDeleteObjectMutation = (
           ...language.arg,
           ...common.args,
         },
-        uid: true,
+        ...returnFields,
       },
     },
   };

--- a/src/lib/graphql/skylark/dynamicQueries/dynamicQueries.test.ts
+++ b/src/lib/graphql/skylark/dynamicQueries/dynamicQueries.test.ts
@@ -1,36 +1,20 @@
-import {
-  episodeObjectOperations,
-  setObjectOperations,
-} from "src/__tests__/utils/objectOperations";
+import { episodeObjectOperations } from "src/__tests__/utils/objectOperations";
 import { SkylarkObjectOperations } from "src/interfaces/skylark";
 
 import { createGetObjectQuery, createSearchObjectsQuery } from ".";
 
 describe("createGetObjectQuery", () => {
   test("returns null when the object doesn't have a get operation", () => {
-    const got = createGetObjectQuery(null, []);
+    const got = createGetObjectQuery(null);
 
     expect(got).toBeNull();
   });
 
   test("returns expected GraphQL get query", () => {
-    const got = createGetObjectQuery(episodeObjectOperations, []);
+    const got = createGetObjectQuery(episodeObjectOperations);
 
     expect(got?.loc?.source.body).toEqual(
       "query GET_Episode ($ignoreAvailability: Boolean = true, $uid: String, $externalId: String) { getObject: getEpisode (ignore_availability: $ignoreAvailability, uid: $uid, external_id: $externalId) { __typename _config { primary_field colour display_name } _meta { available_languages language_data { language version } global_data { version } } uid external_id slug synopsis synopsis_short title title_short title_sort episode_number release_date availability (limit: 50) { next_token objects { uid external_id title slug start end timezone } } images (limit: 50) { next_token objects { _meta { available_languages language_data { language version } global_data { version } } uid external_id slug title description type url file_name content_type } } } }",
-    );
-  });
-
-  test("returns expected GraphQL get query with content", () => {
-    const got = createGetObjectQuery(setObjectOperations, [
-      episodeObjectOperations,
-    ]);
-
-    expect(got?.loc?.source.body).toContain(
-      "content (order: ASC, limit: 50) { objects { object { ... on Episode",
-    );
-    expect(got?.loc?.source.body).toEqual(
-      "query GET_SkylarkSet ($ignoreAvailability: Boolean = true, $uid: String, $externalId: String) { getObject: getSkylarkSet (ignore_availability: $ignoreAvailability, uid: $uid, external_id: $externalId) { __typename _config { primary_field colour display_name } _meta { available_languages language_data { language version } global_data { version } } uid slug external_id type title title_short title_sort synopsis synopsis_short release_date description availability (limit: 50) { next_token objects { uid external_id title slug start end timezone } } images (limit: 50) { next_token objects { _meta { available_languages language_data { language version } global_data { version } } uid external_id slug title description type url file_name content_type } } content (order: ASC, limit: 50) { objects { object { ... on Episode { __typename _config { primary_field colour display_name } _meta { available_languages language_data { language version } global_data { version } } uid external_id __Episode__slug: slug __Episode__synopsis: synopsis __Episode__synopsis_short: synopsis_short __Episode__title: title __Episode__title_short: title_short __Episode__title_sort: title_sort __Episode__episode_number: episode_number __Episode__release_date: release_date } } position } } } }",
     );
   });
 });

--- a/src/lib/graphql/skylark/dynamicQueries/getObject.ts
+++ b/src/lib/graphql/skylark/dynamicQueries/getObject.ts
@@ -19,10 +19,11 @@ export const createGetObjectAvailabilityQueryName = (objectType: string) =>
   `GET_${objectType}_AVAILABILITY`;
 export const createGetObjectRelationshipsQueryName = (objectType: string) =>
   `GET_${objectType}_RELATIONSHIPS`;
+export const createGetObjectContentQueryName = (objectType: string) =>
+  `GET_${objectType}_CONTENT`;
 
 export const createGetObjectQuery = (
   object: SkylarkObjectMeta | null,
-  contentTypesToRequest: SkylarkObjectMeta[],
   addLanguageVariable?: boolean,
 ) => {
   if (!object || !object.operations.get) {
@@ -53,7 +54,6 @@ export const createGetObjectQuery = (
         ...common.fields,
         ...generateFieldsToReturn(object.fields, object.name),
         ...generateRelationshipsToReturn(object),
-        ...generateContentsToReturn(object, contentTypesToRequest),
       },
     },
   };
@@ -195,6 +195,44 @@ export const createGetObjectRelationshipsQuery = (
             },
           };
         }, {}),
+      },
+    },
+  };
+
+  const graphQLQuery = jsonToGraphQLQuery(query);
+
+  return gql(graphQLQuery);
+};
+
+export const createGetObjectContentQuery = (
+  object: SkylarkObjectMeta | null,
+  contentTypesToRequest: SkylarkObjectMeta[],
+  addLanguageVariable?: boolean,
+) => {
+  if (!object || !object.operations.get) {
+    return null;
+  }
+  const common = generateVariablesAndArgs(
+    object.name,
+    "Query",
+    addLanguageVariable,
+  );
+
+  const query = {
+    query: {
+      __name: createGetObjectContentQueryName(object.name),
+      __variables: {
+        ...common.variables,
+        uid: "String!",
+      },
+      getObjectContent: {
+        __aliasFor: object.operations.get.name,
+        __args: {
+          ...common.args,
+          uid: new VariableType("uid"),
+        },
+        __typename: true,
+        ...generateContentsToReturn(object, contentTypesToRequest),
       },
     },
   };

--- a/src/lib/graphql/skylark/dynamicQueries/getObject.ts
+++ b/src/lib/graphql/skylark/dynamicQueries/getObject.ts
@@ -95,7 +95,7 @@ export const createGetObjectAvailabilityQuery = (
         },
         availability: {
           __args: {
-            limit: 5,
+            limit: 10,
             next_token: new VariableType("nextToken"),
           },
           next_token: true,
@@ -206,10 +206,10 @@ export const createGetObjectRelationshipsQuery = (
 
 export const createGetObjectContentQuery = (
   object: SkylarkObjectMeta | null,
-  contentTypesToRequest: SkylarkObjectMeta[],
+  contentTypesToRequest: SkylarkObjectMeta[] | null,
   addLanguageVariable?: boolean,
 ) => {
-  if (!object || !object.operations.get) {
+  if (!object || !object.operations.get || !contentTypesToRequest) {
     return null;
   }
   const common = generateVariablesAndArgs(
@@ -224,6 +224,7 @@ export const createGetObjectContentQuery = (
       __variables: {
         ...common.variables,
         uid: "String!",
+        nextToken: "String",
       },
       getObjectContent: {
         __aliasFor: object.operations.get.name,
@@ -232,7 +233,9 @@ export const createGetObjectContentQuery = (
           uid: new VariableType("uid"),
         },
         __typename: true,
-        ...generateContentsToReturn(object, contentTypesToRequest),
+        ...generateContentsToReturn(object, contentTypesToRequest, {
+          nextTokenVariableName: "nextToken",
+        }),
       },
     },
   };

--- a/src/lib/graphql/skylark/dynamicQueries/search.ts
+++ b/src/lib/graphql/skylark/dynamicQueries/search.ts
@@ -10,16 +10,21 @@ import {
 } from "./utils";
 
 export const createSearchObjectsQuery = (
-  objects: SkylarkObjectMeta[],
+  objects: SkylarkObjectMeta[] | null,
   typesToRequest: string[],
 ) => {
   // Default to showing all objects when no types are requested
   const objectsToRequest =
     typesToRequest.length > 0
-      ? objects.filter(({ name }) => typesToRequest.includes(name))
+      ? objects?.filter(({ name }) => typesToRequest.includes(name))
       : objects;
 
-  if (!objects || objects.length === 0 || objectsToRequest.length === 0) {
+  if (
+    !objects ||
+    objects.length === 0 ||
+    !objectsToRequest ||
+    objectsToRequest.length === 0
+  ) {
     return null;
   }
 

--- a/src/lib/graphql/skylark/dynamicQueries/utils.ts
+++ b/src/lib/graphql/skylark/dynamicQueries/utils.ts
@@ -195,8 +195,9 @@ export const generateContentsToReturn = (
     content: {
       __args: {
         order: new EnumType("ASC"),
-        limit: 50,
+        limit: 20,
       },
+      next_token: true,
       objects: {
         object: {
           __on: objectsToRequest.map((object) => ({

--- a/src/lib/graphql/skylark/dynamicQueries/utils.ts
+++ b/src/lib/graphql/skylark/dynamicQueries/utils.ts
@@ -186,6 +186,9 @@ export const generateRelationshipsToReturn = (
 export const generateContentsToReturn = (
   object: SkylarkObjectMeta | null,
   objectsToRequest: SkylarkObjectMeta[],
+  opts: {
+    nextTokenVariableName: string;
+  },
 ) => {
   if (!object || !object.hasContent || objectsToRequest.length === 0) {
     return {};
@@ -195,7 +198,8 @@ export const generateContentsToReturn = (
     content: {
       __args: {
         order: new EnumType("ASC"),
-        limit: 20,
+        limit: 10,
+        next_token: new VariableType(opts.nextTokenVariableName),
       },
       next_token: true,
       objects: {

--- a/src/pages/object/[objectType]/[uid].tsx
+++ b/src/pages/object/[objectType]/[uid].tsx
@@ -1,14 +1,18 @@
+import Head from "next/head";
 import { useRouter } from "next/router";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import { Panel } from "src/components/panel";
+import { PanelTab } from "src/hooks/usePanelObjectState";
 import { SkylarkObjectIdentifier } from "src/interfaces/skylark";
 
 const Object = () => {
   const router = useRouter();
   const { objectType, uid, language } = router.query;
 
-  const queryObject = useMemo(
+  const [tab, setTab] = useState<PanelTab>(PanelTab.Metadata);
+
+  const object = useMemo(
     () =>
       objectType && uid
         ? {
@@ -29,18 +33,28 @@ const Object = () => {
       pathname: "/object/[objectType]/[uid]",
       query: { uid, objectType, language },
     });
+    setTab(PanelTab.Metadata);
   };
 
   return (
     <div className="pt-nav flex w-full">
-      {queryObject && (
+      <Head>
+        <title>{`Skylark | ${objectType} ${uid} (${language})`}</title>
+      </Head>
+      {object && (
         <div
           className="relative mx-auto w-full"
           style={{
             maxHeight: `calc(100vh - 4rem)`,
           }}
         >
-          <Panel isPage object={queryObject} setPanelObject={setPanelObject} />
+          <Panel
+            isPage
+            object={object}
+            tab={tab}
+            setPanelObject={setPanelObject}
+            setTab={setTab}
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->
- Saves the tab state for navigating back/forwards using the Panel arrows. Adds a forward button
- Removes fetching the object content from the GetObject query, and makes it standalone so that we can fetch object content infinitely
- Prefetch the first page of availability when the Panel is opened for the first time, for objects with more than 5 availabilities, they will load only when switched to that tab - also does this for Set Content
- Switches the width / height on the image tab
- Fixes Availability delete

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Feature

#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://skylarkplatform.atlassian.net/browse/SL-2718
https://skylarkplatform.atlassian.net/browse/SL-2729
