### PR TITLE
fix: shift click selecting already checked object, add language check…

### DIFF
--- a/src/components/objectSearch/results/objectSearchResults.component.tsx
+++ b/src/components/objectSearch/results/objectSearchResults.component.tsx
@@ -144,11 +144,11 @@ export const ObjectSearchResults = ({
   );
 
   const checkedRows = useMemo(() => {
-    const searchObjectUids = searchData?.map(({ uid }) => uid);
-
-    return withObjectSelect && checkedObjects && searchObjectUids
+    return withObjectSelect && checkedObjects && searchData
       ? checkedObjects.map((checkedObj) =>
-          searchObjectUids.indexOf(checkedObj.uid),
+          searchData.findIndex((searchDataObj) =>
+            skylarkObjectsAreSame(checkedObj, searchDataObj),
+          ),
         )
       : [];
   }, [checkedObjects, searchData, withObjectSelect]);
@@ -170,7 +170,7 @@ export const ObjectSearchResults = ({
 
           // Once found, we check all boxes after the previous row until and including the given index
           const objectsToCheck = searchData.slice(
-            reverseSortedCheckedRows[firstSmallerIndex] || 0,
+            reverseSortedCheckedRows[firstSmallerIndex] + 1 || 0,
             rowIndex + 1,
           );
 

--- a/src/components/panel/panel.lib.test.tsx
+++ b/src/components/panel/panel.lib.test.tsx
@@ -245,7 +245,7 @@ describe("handleDroppedAvailabilities", () => {
     expect(got.errors).toEqual([
       {
         object: expect.any(Object),
-        type: HandleDropErrorType.OBJECTS_ARE_SAME,
+        type: HandleDropErrorType.INVALID_OBJECT_TYPE,
       },
       {
         object: expect.any(Object),

--- a/src/components/panel/panel.lib.ts
+++ b/src/components/panel/panel.lib.ts
@@ -54,9 +54,13 @@ export const handleDroppedRelationships = ({
       updatedRelationshipObjects: ParsedSkylarkObjectRelationships[];
       errors: HandleDropError[];
     } => {
-      if (panelObject.uid === droppedObject.uid) {
+      const droppedObjectRelationshipName = objectMetaRelationships.find(
+        (relationship) => relationship.objectType === droppedObject.objectType,
+      )?.relationshipName;
+
+      if (!droppedObjectRelationshipName) {
         const error: HandleDropError = {
-          type: HandleDropErrorType.OBJECTS_ARE_SAME,
+          type: HandleDropErrorType.INVALID_OBJECT_TYPE,
           object: droppedObject,
         };
         return {
@@ -65,13 +69,9 @@ export const handleDroppedRelationships = ({
         };
       }
 
-      const droppedObjectRelationshipName = objectMetaRelationships.find(
-        (relationship) => relationship.objectType === droppedObject.objectType,
-      )?.relationshipName;
-
-      if (!droppedObjectRelationshipName) {
+      if (panelObject.uid === droppedObject.uid) {
         const error: HandleDropError = {
-          type: HandleDropErrorType.INVALID_OBJECT_TYPE,
+          type: HandleDropErrorType.OBJECTS_ARE_SAME,
           object: droppedObject,
         };
         return {
@@ -152,6 +152,17 @@ export const handleDroppedContents = ({
       updatedContentObjects: AddedSkylarkObjectContentObject[];
       errors: HandleDropError[];
     } => {
+      if (droppedObject.objectType === BuiltInSkylarkObjectType.Availability) {
+        const error: HandleDropError = {
+          type: HandleDropErrorType.INVALID_OBJECT_TYPE,
+          object: droppedObject,
+        };
+        return {
+          ...previous,
+          errors: [...previous.errors, error],
+        };
+      }
+
       if (panelObject.uid === droppedObject.uid) {
         const error: HandleDropError = {
           type: HandleDropErrorType.OBJECTS_ARE_SAME,
@@ -170,17 +181,6 @@ export const handleDroppedContents = ({
       ) {
         const error: HandleDropError = {
           type: HandleDropErrorType.EXISTING_LINK,
-          object: droppedObject,
-        };
-        return {
-          ...previous,
-          errors: [...previous.errors, error],
-        };
-      }
-
-      if (droppedObject.objectType === BuiltInSkylarkObjectType.Availability) {
-        const error: HandleDropError = {
-          type: HandleDropErrorType.INVALID_OBJECT_TYPE,
           object: droppedObject,
         };
         return {
@@ -226,9 +226,9 @@ export const handleDroppedAvailabilities = ({
       updatedAvailabilityObjects: ParsedSkylarkObject[];
       errors: HandleDropError[];
     } => {
-      if (panelObject.uid === droppedObject.uid) {
+      if (droppedObject.objectType !== BuiltInSkylarkObjectType.Availability) {
         const error: HandleDropError = {
-          type: HandleDropErrorType.OBJECTS_ARE_SAME,
+          type: HandleDropErrorType.INVALID_OBJECT_TYPE,
           object: droppedObject,
         };
         return {
@@ -237,9 +237,9 @@ export const handleDroppedAvailabilities = ({
         };
       }
 
-      if (droppedObject.objectType !== BuiltInSkylarkObjectType.Availability) {
+      if (panelObject.uid === droppedObject.uid) {
         const error: HandleDropError = {
-          type: HandleDropErrorType.INVALID_OBJECT_TYPE,
+          type: HandleDropErrorType.OBJECTS_ARE_SAME,
           object: droppedObject,
         };
         return {

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -174,7 +174,10 @@ export const addCloudinaryOnTheFlyImageTransformation = (
 export const skylarkObjectsAreSame = (
   obj1: ParsedSkylarkObject,
   obj2: ParsedSkylarkObject,
-) => obj1.uid === obj2.uid && obj1.objectType === obj2.objectType;
+) =>
+  obj1.uid === obj2.uid &&
+  obj1.objectType === obj2.objectType &&
+  obj1.meta.language === obj2.meta.language;
 
 export const skylarkObjectIsInArray = (
   objToFind: ParsedSkylarkObject,


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->
Fixes a few issues I found during a demo:
1. Reorders how the errors are determined so the is_same_object happens after checking object type (minimises the toasts that are shown)
2. Fixes shift + click re-checking an already checked item (fixes drag box showing numberOfCheckboxes + 1 at the moment )
F3. ixes displaying which objects are checked when no language is used in search (previously it was using UID, now it also uses language)

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Bugfix

#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://skylarkplatform.atlassian.net/browse/< ticket_id >

