### PR TITLE
feat: handle objects without list query

### DIFF
--- a/src/interfaces/skylark/objectOperations.ts
+++ b/src/interfaces/skylark/objectOperations.ts
@@ -3,6 +3,7 @@ import { GQLScalars } from "src/interfaces/graphql/introspection";
 export enum BuiltInSkylarkObjectType {
   Availability = "Availability",
   SkylarkImage = "SkylarkImage",
+  SkylarkFavoriteList = "SkylarkFavoriteList",
 }
 
 export enum SkylarkSystemField {
@@ -72,7 +73,7 @@ interface Mutation extends BaseQueryMutation {
 
 export interface SkylarkObjectOperations {
   get: Query | null;
-  list: Query | null;
+  list?: Query | null;
   create: Mutation;
   update: Mutation;
   delete: Mutation;

--- a/src/interfaces/skylark/objectOperations.ts
+++ b/src/interfaces/skylark/objectOperations.ts
@@ -72,8 +72,8 @@ interface Mutation extends BaseQueryMutation {
 }
 
 export interface SkylarkObjectOperations {
-  get: Query | null;
-  list?: Query | null;
+  get: Query;
+  list: Query | null;
   create: Mutation;
   update: Mutation;
   delete: Mutation;

--- a/src/lib/skylark/objects.ts
+++ b/src/lib/skylark/objects.ts
@@ -25,12 +25,15 @@ import {
   SkylarkObjectRelationship,
   ParsedSkylarkObject,
   SkylarkObjectIdentifier,
-  ParsedSkylarkObjectConfig,
 } from "src/interfaces/skylark";
 import { getObjectTypeFromListingTypeName } from "src/lib/utils";
 import { ObjectError } from "src/lib/utils/errors";
 
 import { parseObjectInputFields, parseObjectRelationships } from "./parsers";
+
+const objectsWithoutListQuery: string[] = [
+  BuiltInSkylarkObjectType.SkylarkFavoriteList,
+];
 
 const getObjectInterface = (
   schemaTypes: IntrospectionQuery["__schema"]["types"],
@@ -320,7 +323,7 @@ export const getObjectOperations = (
 
   if (
     !getQuery ||
-    !listQuery ||
+    (!listQuery && !objectsWithoutListQuery.includes(objectType)) ||
     !createMutation ||
     !updateMutation ||
     !deleteMutation
@@ -402,10 +405,12 @@ export const getObjectOperations = (
       type: "Query",
       name: getQuery.name,
     },
-    list: {
-      type: "Query",
-      name: listQuery.name,
-    },
+    list: listQuery
+      ? {
+          type: "Query",
+          name: listQuery.name,
+        }
+      : undefined,
     create: {
       type: "Mutation",
       name: createMutation.name,

--- a/src/lib/skylark/objects.ts
+++ b/src/lib/skylark/objects.ts
@@ -410,7 +410,7 @@ export const getObjectOperations = (
           type: "Query",
           name: listQuery.name,
         }
-      : undefined,
+      : null,
     create: {
       type: "Mutation",
       name: createMutation.name,


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->

The new `SkylarkFavoriteList` object doesn't have a list query. Need to allow `listQuery` to be undefined.

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Bugfix


