### PR TITLE
feat: resize panel on double click of drag bar

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,15 +21,15 @@ jobs:
       - run: yarn lint
       - run: yarn prettier:check
       - run: yarn test:ci
-      - name: Upload coverage reports to Codecov with GitHub Action
-        uses: codecov/codecov-action@v3
-      - name: Test Report
-        uses: dorny/test-reporter@v1
-        if: success() || failure()
-        with:
-          name: Frontend Unit Test Results
-          path: "coverage/jest-*.xml"
-          reporter: jest-junit
+      # - name: Upload coverage reports to Codecov with GitHub Action
+      #   uses: codecov/codecov-action@v3
+      # - name: Test Report
+      #   uses: dorny/test-reporter@v1
+      #   if: success() || failure()
+      #   with:
+      #     name: Frontend Unit Test Results
+      #     path: "coverage/jest-*.xml"
+      #     reporter: jest-junit
       - name: Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/src/components/contentLibrary/contentLibrary.component.tsx
+++ b/src/components/contentLibrary/contentLibrary.component.tsx
@@ -206,7 +206,7 @@ export const ContentLibrary = () => {
             <m.div
               data-testid="drag-bar"
               key={windowSize}
-              className="hidden w-3 cursor-col-resize items-center bg-manatee-100 md:flex"
+              className="hidden w-3 cursor-pointer items-center bg-manatee-100 md:flex"
               onDrag={handleDrag}
               onDragStart={() => {
                 if (containerRef.current) {
@@ -221,6 +221,15 @@ export const ContentLibrary = () => {
               dragConstraints={{ top: 0, left: 0, right: 0, bottom: 0 }}
               dragElastic={0}
               dragMomentum={false}
+              onDoubleClick={() => {
+                const halfWindowWidth = window.innerWidth / 2;
+
+                const newObjectListingWidth =
+                  panelWidth.get() === halfWindowWidth
+                    ? window.innerWidth - MINIMUM_SIZES.panel
+                    : halfWindowWidth;
+                objectListingWidth.set(newObjectListingWidth);
+              }}
             >
               <div className="mx-1 h-20 w-full rounded bg-manatee-600"></div>
             </m.div>


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->

Double clicking the Panel drag bar will resize it to be half of the screen. If its already half of the screen, it'll resize to the smallest width.

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Feature


