### PR TITLE
refactor: Generic GraphQL Errors Toast, modify GraphQL request field parser 

### DIFF
--- a/src/components/modals/createObjectModal/createObjectModal.component.tsx
+++ b/src/components/modals/createObjectModal/createObjectModal.component.tsx
@@ -7,7 +7,10 @@ import { toast } from "react-toastify";
 import { Button } from "src/components/button";
 import { SkylarkObjectFieldInput } from "src/components/inputs";
 import { LanguageSelect, ObjectTypeSelect } from "src/components/inputs/select";
-import { Toast } from "src/components/toast/toast.component";
+import {
+  GraphQLRequestErrorToast,
+  Toast,
+} from "src/components/toast/toast.component";
 import { useUpdateObjectMetadata } from "src/hooks/objects/update/useUpdateObjectMetadata";
 import { useCreateObject } from "src/hooks/objects/useCreateObject";
 import { useSkylarkObjectOperations } from "src/hooks/useSkylarkObjectTypes";
@@ -91,12 +94,9 @@ export const CreateObjectModal = ({
     },
     onError: (error) => {
       toast.error(
-        <Toast
+        <GraphQLRequestErrorToast
           title={`Error creating object`}
-          message={[
-            `Reason(s):`,
-            ...error.response.errors.map(({ message }) => message),
-          ]}
+          error={error}
         />,
         { autoClose: 10000 },
       );
@@ -124,14 +124,11 @@ export const CreateObjectModal = ({
     },
     onError: (error, object) => {
       toast.error(
-        <Toast
+        <GraphQLRequestErrorToast
           title={`Error creating ${
             object.language ? `"${object.language}" ` : ""
           }translation`}
-          message={[
-            `Reason(s):`,
-            ...error.response.errors.map(({ message }) => message),
-          ]}
+          error={error}
         />,
         { autoClose: 10000 },
       );

--- a/src/components/modals/createObjectModal/createObjectModal.test.tsx
+++ b/src/components/modals/createObjectModal/createObjectModal.test.tsx
@@ -26,7 +26,7 @@ const validateErrorToastShown = async (message: string) => {
   const withinToast = within(screen.getByTestId("toast"));
   expect(withinToast.getByText(message)).toBeInTheDocument();
   expect(withinToast.getByText("Reason(s):")).toBeInTheDocument();
-  expect(withinToast.getByText("invalid input")).toBeInTheDocument();
+  expect(withinToast.getByText("- invalid input")).toBeInTheDocument();
 };
 
 describe("Create Object (new object)", () => {

--- a/src/components/modals/deleteObjectModal/deleteObjectModal.component.tsx
+++ b/src/components/modals/deleteObjectModal/deleteObjectModal.component.tsx
@@ -4,7 +4,10 @@ import { GrClose } from "react-icons/gr";
 import { toast } from "react-toastify";
 
 import { Button } from "src/components/button";
-import { Toast } from "src/components/toast/toast.component";
+import {
+  GraphQLRequestErrorToast,
+  Toast,
+} from "src/components/toast/toast.component";
 import { useDeleteObject } from "src/hooks/objects/useDeleteObject";
 
 interface DeleteObjectModalProps {
@@ -60,12 +63,9 @@ export const DeleteObjectModal = ({
     },
     onError: (error) => {
       toast.error(
-        <Toast
+        <GraphQLRequestErrorToast
           title={`Error deleting object`}
-          message={[
-            `Reason(s):`,
-            ...error.response.errors.map(({ message }) => message),
-          ]}
+          error={error}
         />,
         { autoClose: 10000 },
       );

--- a/src/components/modals/deleteObjectModal/deleteObjectModal.test.tsx
+++ b/src/components/modals/deleteObjectModal/deleteObjectModal.test.tsx
@@ -195,7 +195,7 @@ test("GraphQL returns an error when deleting object, shows toast", async () => {
   const withinToast = within(screen.getByTestId("toast"));
   expect(withinToast.getByText("Error deleting object")).toBeInTheDocument();
   expect(withinToast.getByText("Reason(s):")).toBeInTheDocument();
-  expect(withinToast.getByText("invalid input")).toBeInTheDocument();
+  expect(withinToast.getByText("- invalid input")).toBeInTheDocument();
 
   expect(onDeleteSuccess).not.toHaveBeenCalled();
 });

--- a/src/components/panel/panel.component.tsx
+++ b/src/components/panel/panel.component.tsx
@@ -1,10 +1,13 @@
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 
 import { Tabs } from "src/components/tabs/tabs.component";
-import { Toast } from "src/components/toast/toast.component";
+import {
+  GraphQLRequestErrorToast,
+  Toast,
+} from "src/components/toast/toast.component";
 import { useGetObject } from "src/hooks/objects/get/useGetObject";
 import { useGetObjectPrefetchQueries } from "src/hooks/objects/get/useGetObjectPrefetchQueries";
 import { useUpdateAvailabilityAssignedTo } from "src/hooks/objects/update/useUpdateAvailabilityAssignedTo";
@@ -159,13 +162,7 @@ const displayHandleDroppedErrors = (
 
 const showUpdateErrorToast = (error: GQLSkylarkErrorResponse) =>
   toast.error(
-    <Toast
-      title={`Error saving changes`}
-      message={[
-        `Reason(s):`,
-        ...error.response.errors.map(({ message }) => message),
-      ]}
-    />,
+    <GraphQLRequestErrorToast title={`Error saving changes`} error={error} />,
     { autoClose: 10000 },
   );
 

--- a/src/components/panel/panel.test.tsx
+++ b/src/components/panel/panel.test.tsx
@@ -111,7 +111,7 @@ const validateErrorToastShown = async () => {
   const withinToast = within(screen.getByTestId("toast"));
   expect(withinToast.getByText("Error saving changes")).toBeInTheDocument();
   expect(withinToast.getByText("Reason(s):")).toBeInTheDocument();
-  expect(withinToast.getByText("invalid input")).toBeInTheDocument();
+  expect(withinToast.getByText("- invalid input")).toBeInTheDocument();
 };
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/src/components/toast/toast.component.tsx
+++ b/src/components/toast/toast.component.tsx
@@ -7,6 +7,7 @@ import {
 } from "react-toastify";
 
 import { Cross } from "src/components/icons";
+import { GQLSkylarkErrorResponse } from "src/interfaces/skylark";
 
 export interface ToastProps extends Partial<ToastContentProps> {
   title: string;
@@ -95,5 +96,23 @@ export const Toast = ({
         </div>
       )}
     </div>
+  );
+};
+
+export const GraphQLRequestErrorToast = ({
+  title,
+  error,
+}: {
+  title: ToastProps["title"];
+  error: GQLSkylarkErrorResponse;
+}) => {
+  return (
+    <Toast
+      title={title}
+      message={[
+        `Reason(s):`,
+        ...error.response.errors.map(({ message }) => `- ${message}`),
+      ]}
+    />
   );
 };

--- a/src/constants/skylark.ts
+++ b/src/constants/skylark.ts
@@ -49,8 +49,6 @@ export const SYSTEM_FIELDS: string[] = [
   SkylarkSystemField.UID,
   SkylarkSystemField.ExternalID,
   SkylarkSystemField.Type,
-  SkylarkSystemField.DataSourceID,
-  SkylarkSystemField.DataSourceFields,
 ];
 // Helpful way to priorise common display names when one isn't set
 export const DISPLAY_NAME_PRIORITY = [

--- a/src/lib/skylark/availability/availability.ts
+++ b/src/lib/skylark/availability/availability.ts
@@ -15,6 +15,9 @@ dayjs.extend(localizedFormat);
 dayjs.extend(relativeTime);
 dayjs.extend(utc);
 
+export const AWS_EARLIEST_DATE = "1970-01-01T00:00:00.000Z";
+export const AWS_LATEST_DATE = "2038-01-19T03:14:07.000Z"; // Also the 2038 problem
+
 export const getSingleAvailabilityStatus = (
   now: dayjs.Dayjs,
   start: string,
@@ -74,7 +77,7 @@ export const formatReadableDate = (date?: string | null) =>
   date ? dayjs(date).format("llll") : "";
 
 export const is2038Problem = (date: string) => {
-  return dayjs(date).isSame("2038-01-19T03:14:07.000Z");
+  return dayjs(date).isSame(AWS_LATEST_DATE);
 };
 
 export const getRelativeTimeFromDate = (

--- a/src/lib/skylark/parsers.test.ts
+++ b/src/lib/skylark/parsers.test.ts
@@ -19,6 +19,7 @@ import {
   SkylarkSystemField,
 } from "src/interfaces/skylark";
 
+import { AWS_EARLIEST_DATE, AWS_LATEST_DATE } from "./availability";
 import {
   parseInputFieldValue,
   parseMetadataForGraphQLRequest,
@@ -805,11 +806,12 @@ describe("parseMetadataForGraphQLRequest", () => {
     },
   ];
 
-  test("returns empty object values when either null or empty string is given unless if type is a string and not a system field", () => {
+  test("returns nulled object values when either null or empty string is given unless field is UID", () => {
     const metadata: Record<string, SkylarkObjectMetadataField> = {
       title: "",
       date: "",
       int: null,
+      [SkylarkSystemField.UID]: "",
       [SkylarkSystemField.ExternalID]: "",
     };
     const got = parseMetadataForGraphQLRequest(
@@ -819,6 +821,8 @@ describe("parseMetadataForGraphQLRequest", () => {
     );
     expect(got).toEqual({
       title: "",
+      date: null,
+      int: null,
     });
   });
 
@@ -904,7 +908,7 @@ describe("parseMetadataForGraphQLRequest", () => {
       expect(got).toEqual({ title: "string" });
     });
 
-    test("does not change the start and end fields when no value is given", () => {
+    test("sends the largest and smallest AWS date values for the start and end fields when no value is given", () => {
       const metadata: Record<string, SkylarkObjectMetadataField> = {
         title: "string",
         [SkylarkAvailabilityField.Timezone]: "+01:00",
@@ -916,7 +920,11 @@ describe("parseMetadataForGraphQLRequest", () => {
         metadata,
         availabilityInputFields,
       );
-      expect(got).toEqual({ title: "string" });
+      expect(got).toEqual({
+        title: "string",
+        start: AWS_EARLIEST_DATE,
+        end: AWS_LATEST_DATE,
+      });
     });
 
     // TODO TIMEZONE - enable after fixing datetime-local input


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->

- Makes Error Toast more generic
- Refactors the values sent to GraphQL from a form

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Refactoring
#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://skylarkplatform.atlassian.net/browse/< ticket_id >

