### PR TITLE
refactor: minimise Percy snapshots for free tier, use Feather Icon set

### DIFF
--- a/cypress/e2e/auth.cy.ts
+++ b/cypress/e2e/auth.cy.ts
@@ -23,8 +23,6 @@ describe("Auth", () => {
       uriInput.clear();
       tokenInput.clear();
       cy.get("button").should("be.disabled");
-
-      cy.percySnapshot("Auth - modal - no input");
     });
   });
 
@@ -57,7 +55,6 @@ describe("Auth", () => {
         "border-success",
       );
       cy.get('input[name="API Key"]').should("have.class", "border-success");
-      cy.percySnapshot("Auth - modal - successful input");
     });
   });
 
@@ -74,8 +71,6 @@ describe("Auth", () => {
       cy.get("button").should("be.disabled");
       cy.get('input[name="GraphQL URL"]').should("have.class", "border-error");
       cy.get('input[name="API Key"]').should("have.class", "border-error");
-
-      cy.percySnapshot("Auth - modal - invalid input");
     });
   });
 

--- a/cypress/e2e/contentLibrary/createObjectModal.cy.ts
+++ b/cypress/e2e/contentLibrary/createObjectModal.cy.ts
@@ -80,8 +80,6 @@ describe("Create Object Modal", () => {
 
   it("opens the create object modal", () => {
     openModal();
-
-    cy.percySnapshot("Homepage - create object modal");
   });
 
   it("displays an objects display_name in a select", () => {
@@ -93,8 +91,6 @@ describe("Create Object Modal", () => {
       cy.get("[data-testid=select-options]").within(() => {
         cy.contains("Set");
       });
-
-      cy.percySnapshot("Homepage - create object modal - object type select");
     });
   });
 
@@ -109,7 +105,7 @@ describe("Create Object Modal", () => {
 
       cy.contains("button", "Create Episode").should("be.disabled");
 
-      cy.percySnapshot("Homepage - create object modal - object type selected");
+      cy.percySnapshot("Create Object Modal");
     });
   });
 

--- a/cypress/e2e/contentLibrary/objectPanel.cy.ts
+++ b/cypress/e2e/contentLibrary/objectPanel.cy.ts
@@ -214,7 +214,7 @@ describe("Content Library - Object Panel", () => {
         "equal",
         "Series Premiere. Eddard Stark is torn between his family and an old friend when asked to serve at the side of King Robert Baratheon; Viserys plans to wed his sister to a nomadic warlord in exchange for an army.",
       );
-    cy.percySnapshot("Homepage - metadata panel - fields");
+    cy.percySnapshot("Homepage - object panel open");
   });
 
   it("close Panel", () => {
@@ -236,7 +236,6 @@ describe("Content Library - Object Panel", () => {
       cy.get("[data-testid=graphql-query-modal-button]").parent().click();
     });
     cy.contains("Query for");
-    cy.percySnapshot("Homepage - object panel - graphql query");
   });
 
   it("create translation", () => {
@@ -309,8 +308,6 @@ describe("Content Library - Object Panel", () => {
           "O Inverno Está Chegando",
         );
       });
-
-      cy.percySnapshot("Homepage - object panel - fields - pt-PT");
     });
 
     it("edit metadata and cancel", () => {
@@ -329,8 +326,6 @@ describe("Content Library - Object Panel", () => {
         cy.contains("button", "Cancel").should("not.be.disabled");
       });
       cy.contains("Editing");
-
-      cy.percySnapshot("Homepage - object panel - fields (edit)");
 
       // Test cancel
       cy.contains("Cancel").click();
@@ -375,8 +370,6 @@ describe("Content Library - Object Panel", () => {
           "match",
           /https:\/\/media.showcase.skylarkplatform.com\/skylarkimages\/4h6gok37lvcmln3jz7pjsmzrte\/01H4MMBWH8J6E85G7PEZQ96RK4\/01H4MMC39TYKJ0T2A4M0Y8XH1E/,
         );
-
-      cy.percySnapshot("Homepage - object panel - imagery");
     });
 
     it("navigates to the image object using the object button", () => {
@@ -450,8 +443,6 @@ describe("Content Library - Object Panel", () => {
       cy.contains("Homepage").should("exist");
       cy.openContentLibraryObjectPanelByText("Homepage");
       cy.contains("button", "Content").click();
-
-      cy.percySnapshot("Homepage - object panel - content");
     });
 
     it("navigates to the set content using the object button", () => {
@@ -527,8 +518,6 @@ describe("Content Library - Object Panel", () => {
         })
         .should("deep.eq", homepageContentOrdered);
 
-      cy.percySnapshot("Homepage - object panel - content (edit)");
-
       // Test deleting
       cy.contains("Discover")
         .parent()
@@ -563,8 +552,6 @@ describe("Content Library - Object Panel", () => {
           "Miraculous Season 5",
           "Home page hero",
         ]);
-
-      cy.percySnapshot("Homepage - object panel - content (reorder)");
 
       // Test cancel
       cy.contains("Cancel").click();
@@ -643,8 +630,6 @@ describe("Content Library - Object Panel", () => {
       cy.contains("button", "Relationships").click();
 
       cy.contains("StreamTVLoadingScreen.png");
-
-      cy.percySnapshot("Homepage - object panel - relationships");
     });
 
     it("adds Relationships using the Object Search modal", () => {
@@ -689,8 +674,6 @@ describe("Content Library - Object Panel", () => {
       cy.contains("button", "Appears In").click();
 
       cy.contains("Wes Anderson Movies Collection");
-
-      cy.percySnapshot("Homepage - object panel - content of");
     });
 
     it("navigates to the Set using the object button", () => {
@@ -751,8 +734,6 @@ describe("Content Library - Object Panel", () => {
       cy.contains("Active in the past");
       cy.contains("Time Window");
       cy.contains("Audience");
-
-      cy.percySnapshot("Homepage - object panel - availability");
     });
 
     it("navigates to the availability using the object button", () => {
@@ -871,8 +852,6 @@ describe("Content Library - Object Panel", () => {
       cy.contains("Standard");
       cy.contains("PC");
       cy.contains("SmartPhone");
-
-      cy.percySnapshot("Homepage - object panel - availability dimensions");
     });
 
     it("removes a dimension", () => {

--- a/cypress/e2e/contentLibrary/search.cy.ts
+++ b/cypress/e2e/contentLibrary/search.cy.ts
@@ -134,7 +134,6 @@ describe("Content Library - Search", () => {
 
     cy.contains("GOT S02").should("not.exist");
     cy.contains("GOT S01 Trailer").should("exist");
-    cy.percySnapshot("Homepage - got search data");
   });
 
   it("displays an objects display_name in the object type filter", () => {
@@ -150,12 +149,10 @@ describe("Content Library - Search", () => {
   it("filters for only Assets", () => {
     cy.contains("Asset").should("exist");
     cy.contains("Filters").click();
-    cy.percySnapshot("Homepage - filters - open");
 
     cy.contains("Toggle all").click();
     cy.contains("Apply").should("be.disabled");
     cy.get("#checkbox-object-type-skylarkasset").click();
-    cy.percySnapshot("Homepage - filters - object types selected");
     cy.contains("Apply").should("not.be.disabled").click();
   });
 
@@ -177,9 +174,7 @@ describe("Content Library - Search", () => {
     ].forEach((field) => {
       columnsFilters.get(`#checkbox-columns-${field}`).click();
     });
-    cy.percySnapshot("Homepage - filters - fields selected");
     cy.contains("Apply").should("not.be.disabled").click();
-    cy.percySnapshot("Homepage - filters - fields active");
   });
 
   it("filters to en-GB only got content", () => {

--- a/cypress/e2e/import/csv.cy.ts
+++ b/cypress/e2e/import/csv.cy.ts
@@ -65,7 +65,6 @@ describe("Import/CSV", () => {
     cy.get(".btn-outline")
       .contains("New import")
       .should("have.class", "btn-disabled");
-    cy.percySnapshot("import/csv");
   });
 
   it("displays an objects display_name in a select", () => {
@@ -74,15 +73,12 @@ describe("Import/CSV", () => {
     cy.get("[data-testid=select-options]").within(() => {
       cy.contains("Set");
     });
-
-    cy.percySnapshot("import/csv - objectType select");
   });
 
   it("select objectType", () => {
     cy.contains("Download Example CSV").should("have.class", "btn-disabled");
     cy.get('[data-testid="select"]').click();
     cy.get('[data-testid="select-options"]').should("be.visible");
-    cy.percySnapshot("import/csv - objectType select open");
 
     cy.get('[data-testid="select-options"]')
       .get("li > span")
@@ -99,7 +95,6 @@ describe("Import/CSV", () => {
       .should("not.have.class", "btn-disabled")
       .should("have.attr", "href")
       .and("include", "data:text/plain;charset=utf-8,external_id");
-    cy.percySnapshot("import/csv - objectType selected");
   });
 
   it("opens and closes Flatfile", () => {

--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -20,13 +20,11 @@ describe("Navigation", () => {
   it("contains the navigation bar", () => {
     cy.contains("Skylark");
     cy.get("nav").get("ul").find("li").should("have.length", 2);
-    cy.percySnapshot("Navigation - desktop");
   });
 
   it("opens the navigation bar on mobile", () => {
     cy.viewport("iphone-xr");
     cy.get("#mobile-nav-toggle").click();
     cy.get("nav").get("ul").find("li").should("have.length", 2);
-    cy.percySnapshot("Navigation - mobile");
   });
 });

--- a/cypress/e2e/objectPage.cy.ts
+++ b/cypress/e2e/objectPage.cy.ts
@@ -64,7 +64,7 @@ describe("Object Page", () => {
 
     it("loads page", () => {
       cy.contains("Homepage");
-      cy.percySnapshot("Object page - metadata");
+      cy.percySnapshot("Object page");
     });
 
     it("navigates to Content tab, opens an object and checks the URL has updated", () => {

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory } from "@storybook/react";
-import { BsPlusLg, BsPlusCircle } from "react-icons/bs";
+import { FiPlus, FiPlusCircle } from "react-icons/fi";
 
 import { Button } from "./button.component";
 
@@ -94,7 +94,7 @@ GhostIconOnly.args = {
   ...defaultProps,
   variant: "ghost",
   children: undefined,
-  Icon: <BsPlusCircle className="text-xl" />,
+  Icon: <FiPlusCircle className="text-xl" />,
 };
 
 export const Link = Template.bind({});
@@ -138,5 +138,5 @@ FullWidth.args = {
 export const WithIcon = Template.bind({});
 WithIcon.args = {
   ...defaultProps,
-  Icon: <BsPlusLg />,
+  Icon: <FiPlus className="text-xl" />,
 };

--- a/src/components/copyToClipboard/copyToClipboard.component.tsx
+++ b/src/components/copyToClipboard/copyToClipboard.component.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { GrCopy } from "react-icons/gr";
+import { FiCopy } from "react-icons/fi";
 
 interface CopyToClipboardProps {
   value?: string | number | true | JSX.Element | string[];
@@ -8,7 +8,7 @@ interface CopyToClipboardProps {
 
 export const CopyToClipboard = ({ value, className }: CopyToClipboardProps) =>
   value ? (
-    <GrCopy
+    <FiCopy
       aria-label={`Copy ${value} to clipboard`}
       onClick={(e) => {
         e.preventDefault();

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -1,2 +1,3 @@
 export * from "./spinner.component";
 export * from "./filter.component";
+export * from "./reactIconWrappers";

--- a/src/components/icons/reactIconWrappers.tsx
+++ b/src/components/icons/reactIconWrappers.tsx
@@ -1,0 +1,6 @@
+import { FiX as ReactIconFiX } from "react-icons/fi";
+import { IconType } from "react-icons/lib";
+
+export const FiX: IconType = (props) => (
+  <ReactIconFiX {...props} viewBox="4 4 16 16" />
+);

--- a/src/components/inputs/availabilityPicker/availabilityPicker.component.tsx
+++ b/src/components/inputs/availabilityPicker/availabilityPicker.component.tsx
@@ -2,10 +2,10 @@ import { useFloating, offset, flip, size } from "@floating-ui/react";
 import { Popover } from "@headlessui/react";
 import clsx from "clsx";
 import { useState } from "react";
-import { GoTriangleDown } from "react-icons/go";
-import { GrClose } from "react-icons/gr";
+import { FiChevronDown } from "react-icons/fi";
 
 import { Button } from "src/components/button";
+import { FiX } from "src/components/icons";
 import { InputLabel } from "src/components/inputs/label/label.component";
 import { UTC_NAME, Select, TimezoneSelect } from "src/components/inputs/select";
 import { PanelSectionTitle } from "src/components/panel/panelTypography";
@@ -244,10 +244,10 @@ export const AvailabilityPicker = ({
           )}
           <div
             className={clsx(
-              "absolute inset-y-0 right-4 ml-1 flex items-center text-black",
+              "absolute inset-y-0 right-3.5 ml-1 flex items-center text-black",
             )}
           >
-            <GoTriangleDown className="h-3 w-3" aria-hidden="true" />
+            <FiChevronDown className="text-xl" aria-hidden="true" />
           </div>
         </Popover.Button>
         {(activeValues.dimensions || activeValues.timeTravel) && (
@@ -262,7 +262,7 @@ export const AvailabilityPicker = ({
             }}
             aria-label="clear availability"
           >
-            <GrClose className="text-xs" />
+            <FiX className="mr-0.5 text-xs" />
           </button>
         )}
       </div>

--- a/src/components/inputs/checkbox/checkbox.component.tsx
+++ b/src/components/inputs/checkbox/checkbox.component.tsx
@@ -4,7 +4,7 @@ import {
   CheckboxProps as RadixCheckboxProps,
 } from "@radix-ui/react-checkbox";
 import clsx from "clsx";
-import { GoCheck, GoX } from "react-icons/go";
+import { FiCheck, FiX } from "react-icons/fi";
 
 interface CheckboxProps extends RadixCheckboxProps {
   label?: string;
@@ -39,8 +39,8 @@ export const Checkbox = ({
         {...props}
       >
         <Indicator>
-          {checked === "indeterminate" && <GoX />}
-          {checked === true && <GoCheck />}
+          {checked === "indeterminate" && <FiX className="text-lg" />}
+          {checked === true && <FiCheck className="text-lg" />}
         </Indicator>
       </Root>
       {label && (

--- a/src/components/inputs/select/select.component.tsx
+++ b/src/components/inputs/select/select.component.tsx
@@ -16,10 +16,10 @@ import React, {
   Ref,
   ReactNode,
 } from "react";
-import { GoTriangleDown } from "react-icons/go";
-import { GrClose } from "react-icons/gr";
+import { FiChevronDown } from "react-icons/fi";
 import { useVirtual } from "react-virtual";
 
+import { FiX } from "src/components/icons";
 import { Checkbox } from "src/components/inputs/checkbox";
 import { formatObjectField, mergeRefs } from "src/lib/utils";
 
@@ -371,16 +371,16 @@ export const Select = forwardRef(
                       }}
                       data-testid="select-clear-value"
                     >
-                      <GrClose className="text-xs" />
+                      <FiX className="text-xs" />
                     </button>
                   )}
                   <button
                     className={clsx(
                       "h-full",
-                      variant === "pill" ? "mx-2" : "ml-1 mr-4",
+                      variant === "pill" ? "mx-2" : "ml-0.5 mr-3.5",
                     )}
                   >
-                    <GoTriangleDown className="h-3 w-3" aria-hidden="true" />
+                    <FiChevronDown className="text-xl" aria-hidden="true" />
                   </button>
                 </span>
               </Combobox.Button>
@@ -405,10 +405,10 @@ export const Select = forwardRef(
                 <span
                   className={clsx(
                     "pointer-events-none absolute inset-y-0 right-0 flex items-center",
-                    variant === "pill" ? "pr-2" : "pr-4",
+                    variant === "pill" ? "pr-2" : "pr-3.5",
                   )}
                 >
-                  <GoTriangleDown className="h-3 w-3" aria-hidden="true" />
+                  <FiChevronDown className="text-xl" aria-hidden="true" />
                 </span>
               </Combobox.Button>
             )}

--- a/src/components/modals/betaReleaseAuthModal/betaReleaseAuthModal.component.tsx
+++ b/src/components/modals/betaReleaseAuthModal/betaReleaseAuthModal.component.tsx
@@ -3,11 +3,11 @@ import { useQueryClient } from "@tanstack/react-query";
 import clsx from "clsx";
 import { usePlausible } from "next-plausible";
 import React, { useEffect, useState } from "react";
-import { GrClose } from "react-icons/gr";
 import { useDebouncedCallback } from "use-debounce";
 
 import { Button } from "src/components/button";
 import { CopyToClipboard } from "src/components/copyToClipboard/copyToClipboard.component";
+import { FiX } from "src/components/icons";
 import { TextInput } from "src/components/inputs/textInput";
 import { LOCAL_STORAGE } from "src/constants/localStorage";
 import { QueryKeys } from "src/enums/graphql";
@@ -89,6 +89,9 @@ export const AddAuthTokenModal = ({
         queryKey: [QueryKeys.Schema],
         type: "active",
       });
+      await queryClient.refetchQueries({
+        queryKey: [QueryKeys.AccountStatus],
+      });
 
       setIsOpen(false);
     }
@@ -118,7 +121,7 @@ export const AddAuthTokenModal = ({
             onClick={closeModal}
             tabIndex={-1}
           >
-            <GrClose className="text-xl" />
+            <FiX className="text-lg" />
           </button>
 
           <Dialog.Title className="mb-2 font-heading text-2xl md:mb-4 md:text-3xl">

--- a/src/components/modals/createObjectModal/createObjectModal.component.tsx
+++ b/src/components/modals/createObjectModal/createObjectModal.component.tsx
@@ -8,10 +8,10 @@ import React, {
   useState,
 } from "react";
 import { useForm, Controller } from "react-hook-form";
-import { GrClose } from "react-icons/gr";
 import { toast } from "react-toastify";
 
 import { Button } from "src/components/button";
+import { FiX } from "src/components/icons";
 import { SkylarkObjectFieldInput } from "src/components/inputs";
 import { LanguageSelect, ObjectTypeSelect } from "src/components/inputs/select";
 import {
@@ -254,7 +254,7 @@ const CreateObjectModalBody = forwardRef(
           onClick={closeModal}
           tabIndex={-1}
         >
-          <GrClose className="text-xl" />
+          <FiX className="text-lg" />
         </button>
 
         <Dialog.Title className="mb-2 font-heading text-2xl md:mb-4 md:text-3xl">

--- a/src/components/modals/deleteObjectModal/deleteObjectModal.component.tsx
+++ b/src/components/modals/deleteObjectModal/deleteObjectModal.component.tsx
@@ -1,9 +1,9 @@
 import { Dialog } from "@headlessui/react";
 import React from "react";
-import { GrClose } from "react-icons/gr";
 import { toast } from "react-toastify";
 
 import { Button } from "src/components/button";
+import { FiX } from "src/components/icons";
 import {
   GraphQLRequestErrorToast,
   Toast,
@@ -93,7 +93,7 @@ export const DeleteObjectModal = ({
             onClick={closeModal}
             tabIndex={-1}
           >
-            <GrClose className="text-xl" />
+            <FiX className="text-lg" />
           </button>
 
           <Dialog.Title className="mb-2 font-heading text-2xl md:mb-4 md:text-3xl">

--- a/src/components/modals/graphQLQueryModal/graphQLQueryModal.component.tsx
+++ b/src/components/modals/graphQLQueryModal/graphQLQueryModal.component.tsx
@@ -3,10 +3,11 @@ import { AnimatePresence, m } from "framer-motion";
 import { DocumentNode, print, getOperationAST } from "graphql";
 import dynamic from "next/dynamic";
 import { useMemo, useState } from "react";
-import { GrClose, GrCopy, GrGraphQl } from "react-icons/gr";
+import { FiCopy } from "react-icons/fi";
+import { GrGraphQl } from "react-icons/gr";
 
 import { Button } from "src/components/button";
-import { Spinner } from "src/components/icons";
+import { FiX, Spinner } from "src/components/icons";
 import { Tabs } from "src/components/tabs/tabs.component";
 import { Tooltip } from "src/components/tooltip/tooltip.component";
 import { LOCAL_STORAGE } from "src/constants/localStorage";
@@ -221,7 +222,7 @@ export const DisplayGraphQLQueryModal = ({
               className="absolute right-4 top-4 sm:right-8 sm:top-9"
               onClick={close}
             >
-              <GrClose className="text-xl" />
+              <FiX className="text-lg" />
             </button>
 
             <div className="mb-2 px-4 md:mb-4 md:px-8">
@@ -260,7 +261,7 @@ export const DisplayGraphQLQueryModal = ({
                   className="rounded border bg-manatee-100 p-2 shadow transition-colors hover:bg-brand-primary hover:stroke-white sm:p-3"
                   onClick={copyActiveTab}
                 >
-                  <GrCopy className="text-lg md:text-xl" />
+                  <FiCopy className="text-lg md:text-xl" />
                 </button>
               </div>
             </div>

--- a/src/components/modals/searchObjectsModal/searchObjectsModal.component.tsx
+++ b/src/components/modals/searchObjectsModal/searchObjectsModal.component.tsx
@@ -1,8 +1,8 @@
 import { Dialog } from "@headlessui/react";
 import React, { useMemo } from "react";
-import { GrClose } from "react-icons/gr";
 
 import { Button } from "src/components/button";
+import { FiX } from "src/components/icons";
 import {
   ObjectSearch,
   ObjectSearchInitialColumnsState,
@@ -77,7 +77,7 @@ export const SearchObjectsModal = ({
             onClick={closeModal}
             tabIndex={-1}
           >
-            <GrClose className="text-xl" />
+            <FiX className="text-lg" />
           </button>
 
           <div className="px-6 md:px-10">

--- a/src/components/navigation/hamburger/hamburger.component.tsx
+++ b/src/components/navigation/hamburger/hamburger.component.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { SlMenu } from "react-icons/sl";
+import { FiMenu } from "react-icons/fi";
 
 interface Props {
   onClick: () => void;
@@ -12,6 +12,6 @@ export const Hamburger = ({ onClick, className }: Props) => (
     id="mobile-nav-toggle"
     className={clsx("z-50 text-2xl", className)}
   >
-    <SlMenu />
+    <FiMenu />
   </button>
 );

--- a/src/components/navigation/search/search.component.tsx
+++ b/src/components/navigation/search/search.component.tsx
@@ -1,5 +1,5 @@
 import { KeyboardEvent, useState } from "react";
-import { AiOutlineSearch } from "react-icons/ai";
+import { FiSearch } from "react-icons/fi";
 
 interface Props {
   onSearch: (value: string) => void;
@@ -25,7 +25,7 @@ export const QuickSearch = ({ onSearch }: Props) => {
         className="ml-6 w-full border-b-2 border-gray-300 bg-transparent py-1 text-center text-sm placeholder-gray-400 outline-none transition-all group-focus-within:border-black group-focus-within:placeholder-transparent md:ml-0 md:w-0 md:border-gray-500 md:text-left md:group-focus-within:mr-1 md:group-focus-within:w-full md:group-focus-within:px-1 md:group-hover:mr-1 md:group-hover:w-full md:group-hover:px-1"
       />
       <button onClick={() => onSearch(value)}>
-        <AiOutlineSearch className="my-1 h-5 w-5 text-gray-400 transition-colors group-focus-within:text-black md:h-6 md:w-6 md:text-black" />
+        <FiSearch className="my-1 h-5 w-5 text-gray-400 transition-colors group-focus-within:text-black md:h-6 md:w-6 md:text-black" />
       </button>
       <span className="ml-1 hidden overflow-hidden whitespace-nowrap text-sm font-semibold transition-width md:block  md:w-full md:group-focus-within:ml-0 md:group-focus-within:w-0 md:group-hover:ml-0 md:group-hover:w-0">
         {`Quick Search`}

--- a/src/components/objectSearch/search/searchInput/searchInput.component.tsx
+++ b/src/components/objectSearch/search/searchInput/searchInput.component.tsx
@@ -1,9 +1,9 @@
 import clsx from "clsx";
 import { useState } from "react";
-import { FiRefreshCw, FiSearch, FiX } from "react-icons/fi";
+import { FiRefreshCw, FiSearch } from "react-icons/fi";
 import { useDebouncedCallback } from "use-debounce";
 
-import { Filter } from "src/components/icons";
+import { FiX, Filter } from "src/components/icons";
 
 interface SearchInputProps {
   searchQuery: string;
@@ -72,7 +72,7 @@ export const SearchInput = ({
               : "invisible opacity-0",
           )}
         >
-          <FiX className="text-xl" />
+          <FiX className="text-sm" />
         </button>
         <button
           onClick={onRefresh}

--- a/src/components/panel/panelLoading/panelLoading.component.tsx
+++ b/src/components/panel/panelLoading/panelLoading.component.tsx
@@ -22,7 +22,7 @@ export const PanelLoading = ({
             data-chromatic="ignore"
             className="flex w-full items-center justify-center py-10"
           >
-            <Spinner className="h-10 w-10  animate-spin md:h-14 md:w-14" />
+            <Spinner className="h-10 w-10 animate-spin md:h-14 md:w-14" />
           </div>
         )}
       </div>

--- a/src/components/panel/panelSections/panelHeader.component.tsx
+++ b/src/components/panel/panelSections/panelHeader.component.tsx
@@ -9,7 +9,6 @@ import {
   FiExternalLink,
   FiMoreVertical,
   FiTrash2,
-  FiX,
 } from "react-icons/fi";
 import { GrGraphQl } from "react-icons/gr";
 
@@ -19,6 +18,7 @@ import {
   DropdownMenu,
   DropdownMenuButton,
 } from "src/components/dropdown/dropdown.component";
+import { FiX } from "src/components/icons";
 import { LanguageSelect } from "src/components/inputs/select";
 import {
   CreateObjectModal,
@@ -245,7 +245,7 @@ export const PanelHeader = ({
           <Button
             variant="ghost"
             onClick={closePanel}
-            Icon={<FiX className="text-2xl" />}
+            Icon={<FiX className="text-lg" />}
             aria-label="Close Panel"
           />
         )}


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->

- Reduces the number of Percy screenshots taken in Cypress tests as we're moving to the free tier
- Move icons to use the Feather Icon set so that we have more consistency

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Refactoring

