### PR TITLE
feat: Local Storage changes for Credentials and Content Library Tabs

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -9,12 +9,6 @@ import { LOCAL_STORAGE } from "./src/constants/localStorage";
 // Establish API mocking before all tests.
 beforeAll(() => {
   Storage.prototype.getItem = jest.fn().mockImplementation((key) => {
-    if (key === LOCAL_STORAGE.betaAuth.uri) {
-      return "http://localhost:3000";
-    }
-    if (key === LOCAL_STORAGE.betaAuth.token) {
-      return "token";
-    }
     if (key === LOCAL_STORAGE.auth.active) {
       return JSON.stringify({
         uri: "http://localhost:3000",

--- a/src/components/contentLibrary/contentLibrary.component.tsx
+++ b/src/components/contentLibrary/contentLibrary.component.tsx
@@ -28,7 +28,7 @@ import {
   DragType,
 } from "src/lib/dndkit/dndkit";
 
-import { TabbedObjectSearch } from "./tabbedObjectSearch/tabbedObjectSearch.component";
+import { TabbedObjectSearchWithAccount } from "./tabbedObjectSearch/tabbedObjectSearch.component";
 
 const INITIAL_PANEL_PERCENTAGE = 70;
 const MINIMUM_SIZES = {
@@ -231,7 +231,7 @@ export const ContentLibrary = () => {
           {isDraggingObject && (
             <div className="absolute inset-0 z-[100] block bg-black/5"></div>
           )}
-          <TabbedObjectSearch
+          <TabbedObjectSearchWithAccount
             panelObject={activePanelObject}
             setPanelObject={setPanelObject}
             isPanelOpen={!!activePanelObject}

--- a/src/components/contentLibrary/contentLibrary.test.tsx
+++ b/src/components/contentLibrary/contentLibrary.test.tsx
@@ -1,6 +1,7 @@
 import { graphql } from "msw";
 
 import GQLSkylarkAllAvailTestMovieFixture from "src/__tests__/fixtures/skylark/queries/getObject/fantasticMrFox_All_Availabilities.json";
+import GQLSkylarkUserAccountFixture from "src/__tests__/fixtures/skylark/queries/getUserAndAccount.json";
 import GQLSkylarkAllAvailTestMovieSearchFixture from "src/__tests__/fixtures/skylark/queries/search/fantasticMrFox_All_Availabilities.json";
 import GQLGameOfThronesSearchResults from "src/__tests__/fixtures/skylark/queries/search/gotPage1.json";
 import { server } from "src/__tests__/mocks/server";
@@ -12,7 +13,6 @@ import {
   waitFor,
   within,
 } from "src/__tests__/utils/test-utils";
-import { GQLSkylarkAccountResponse } from "src/interfaces/skylark";
 
 import { ContentLibrary } from "./contentLibrary.component";
 
@@ -89,11 +89,14 @@ test("displays the number of search results", async () => {
   server.use(
     // Override GET_USER_AND_ACCOUNT query so the language sent is null
     graphql.query("GET_USER_AND_ACCOUNT", (req, res, ctx) => {
-      const data: GQLSkylarkAccountResponse = {
+      const data = {
+        ...GQLSkylarkUserAccountFixture.data,
         getAccount: {
-          config: null,
-          account_id: "123",
-          skylark_version: "latest",
+          ...GQLSkylarkUserAccountFixture.data.getAccount,
+          config: {
+            ...GQLSkylarkUserAccountFixture.data.getAccount.config,
+            default_language: null,
+          },
         },
       };
       return res(ctx.data(data));

--- a/src/components/contentLibrary/tabbedObjectSearch/tabbedObjectSearch.component.tsx
+++ b/src/components/contentLibrary/tabbedObjectSearch/tabbedObjectSearch.component.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import {
   FiCheckSquare,
   FiEdit,
@@ -20,10 +20,11 @@ import {
 import { CreateButtons } from "src/components/objectSearch/createButtons";
 import { OBJECT_SEARCH_PERMANENT_FROZEN_COLUMNS } from "src/components/objectSearch/results/columnConfiguration";
 import { ScrollableTabs } from "src/components/tabs/tabs.component";
-import { LOCAL_STORAGE } from "src/constants/localStorage";
 import { OBJECT_LIST_TABLE } from "src/constants/skylark";
-import { useUser } from "src/contexts/useUser";
+import { useSkylarkCreds } from "src/hooks/localStorage/useCreds";
+import { useObjectSearchTabs } from "src/hooks/localStorage/useObjectSearchTabs";
 import { SearchFilters } from "src/hooks/useSearch";
+import { useUserAccount } from "src/hooks/useUserAccount";
 import {
   BuiltInSkylarkObjectType,
   SkylarkAvailabilityField,
@@ -43,72 +44,7 @@ type TabbedObjectSearchProps = Omit<
   | "initialColumnState"
   | "onFilterChange"
   | "onColumnStateChange"
->;
-
-const saveTabStateToStorage = (
-  accountId: string,
-  {
-    tabs,
-    activeTabIndex,
-    tabsScrollPosition,
-  }: Partial<{
-    tabs: ObjectSearchTab[];
-    activeTabIndex: number;
-    tabsScrollPosition: number;
-  }>,
-) => {
-  if (tabs !== undefined) {
-    localStorage.setItem(
-      LOCAL_STORAGE.accountPrefixed(accountId).contentLibrary.tabState,
-      JSON.stringify(tabs),
-    );
-  }
-
-  if (activeTabIndex !== undefined) {
-    localStorage.setItem(
-      LOCAL_STORAGE.accountPrefixed(accountId).contentLibrary.activeTabIndex,
-      String(activeTabIndex),
-    );
-  }
-
-  if (tabsScrollPosition !== undefined) {
-    localStorage.setItem(
-      LOCAL_STORAGE.accountPrefixed(accountId).contentLibrary
-        .tabsScrollPosition,
-      String(tabsScrollPosition),
-    );
-  }
-};
-
-const readTabStateFromStorage = (accountId: string) => {
-  const valueFromStorage = localStorage.getItem(
-    LOCAL_STORAGE.accountPrefixed(accountId).contentLibrary.tabState,
-  );
-
-  if (!valueFromStorage) {
-    return null;
-  }
-
-  try {
-    return JSON.parse(valueFromStorage) as ObjectSearchTab[];
-  } catch (err) {
-    return null;
-  }
-};
-
-const readIntFromLocalStorage = (name: string): number => {
-  const valueFromStorage = localStorage.getItem(name);
-
-  if (!valueFromStorage) {
-    return 0;
-  }
-
-  try {
-    return parseInt(valueFromStorage);
-  } catch (err) {
-    return 0;
-  }
-};
+> & { accountId: string };
 
 const generateNewTab = (
   name: string,
@@ -247,101 +183,21 @@ const TabOverview = ({
   );
 };
 
-export const TabbedObjectSearch = (props: TabbedObjectSearchProps) => {
-  const { accountId, isLoading: isAccountLoading } = useUser();
-
-  const [activeTabIndex, setActiveTabIndex] = useState(0);
-  const [tabs, setTabs] = useState<ObjectSearchTab[] | undefined>(undefined);
-  const [initialTabsScrollPosition, setInitialTabsScrollPosition] = useState(0);
-
-  useEffect(() => {
-    const setValuesFromLocalStorage = () => {
-      if (accountId) {
-        const tabsFromStorage = readTabStateFromStorage(accountId);
-        const activeIndex = readIntFromLocalStorage(
-          LOCAL_STORAGE.accountPrefixed(accountId).contentLibrary
-            .activeTabIndex,
-        );
-        const tabsScrollPosition = readIntFromLocalStorage(
-          LOCAL_STORAGE.accountPrefixed(accountId).contentLibrary
-            .tabsScrollPosition,
-        );
-
-        setTabs(
-          tabsFromStorage && tabsFromStorage.length > 0
-            ? tabsFromStorage
-            : initialTabs,
-        );
-        setActiveTabIndex(
-          tabsFromStorage && activeIndex && activeIndex < tabsFromStorage.length
-            ? activeIndex
-            : 0,
-        );
-        setInitialTabsScrollPosition(tabsScrollPosition || 0);
-      } else {
-        setTabs(undefined);
-        setActiveTabIndex(0);
-        setInitialTabsScrollPosition(0);
-      }
-    };
-
-    setValuesFromLocalStorage();
-
-    window.addEventListener("storage", setValuesFromLocalStorage);
-    return () => {
-      window.removeEventListener("storage", setValuesFromLocalStorage);
-    };
-  }, [accountId]);
-
-  const activeTab = tabs?.[activeTabIndex];
-
-  const onActiveTabChange = useCallback(
-    (updatedTab: Partial<ObjectSearchTab>) => {
-      const updatedTabs =
-        tabs?.map((tab, index) => {
-          if (index !== activeTabIndex) return tab;
-
-          return {
-            ...tab,
-            ...{
-              ...updatedTab,
-              columnsState: updatedTab.columnsState || tab.columnsState,
-              filters: updatedTab.filters || tab.filters,
-            },
-          };
-        }) || [];
-
-      if (accountId) {
-        saveTabStateToStorage(accountId, { tabs: updatedTabs });
-      }
-      setTabs(updatedTabs);
-    },
-    [accountId, activeTabIndex, tabs],
-  );
-
-  const onActiveTabIndexChange = (newIndex: number) => {
-    if (accountId) {
-      saveTabStateToStorage(accountId, { activeTabIndex: newIndex });
-    }
-    setActiveTabIndex(newIndex);
-  };
-
-  const deleteActiveTab = () => {
-    if (tabs) {
-      const updatedTabs = [...tabs];
-      updatedTabs.splice(activeTabIndex, 1);
-
-      if (updatedTabs.length === 0) {
-        updatedTabs.push(...initialTabs);
-      }
-
-      if (accountId) {
-        saveTabStateToStorage(accountId, { tabs: updatedTabs });
-      }
-      setTabs(updatedTabs);
-      setActiveTabIndex(activeTabIndex > 0 ? activeTabIndex - 1 : 0);
-    }
-  };
+const TabbedObjectSearch = ({
+  accountId,
+  ...props
+}: TabbedObjectSearchProps) => {
+  const {
+    tabs,
+    activeTab,
+    initialTabsScrollPosition,
+    setTabs,
+    modifyActiveTab,
+    setActiveTabIndex,
+    deleteActiveTab,
+    changeActiveTabIndex,
+    saveScrollPosition,
+  } = useObjectSearchTabs(accountId, initialTabs);
 
   const beforeSeparatorClassname =
     "before:absolute before:left-0 before:h-6 before:w-px before:bg-manatee-200 before:content-['']";
@@ -364,10 +220,9 @@ export const TabbedObjectSearch = (props: TabbedObjectSearchProps) => {
                     id: tab.id,
                   }))}
                   selectedTab={activeTab?.id || ""}
-                  onChange={({ index }) => onActiveTabIndexChange(index)}
+                  onChange={({ index }) => changeActiveTabIndex(index)}
                   onScroll={({ scrollLeft: tabsScrollPosition }) =>
-                    accountId &&
-                    saveTabStateToStorage(accountId, { tabsScrollPosition })
+                    saveScrollPosition(tabsScrollPosition)
                   }
                 />
                 <button
@@ -380,9 +235,11 @@ export const TabbedObjectSearch = (props: TabbedObjectSearchProps) => {
                       const newTab = generateNewTab(
                         `View ${existingTabs ? existingTabs.length + 1 : 1}`,
                       );
-                      return existingTabs
+                      const updatedTabs = existingTabs
                         ? [...existingTabs, newTab]
                         : [newTab];
+
+                      return updatedTabs;
                     });
                     setActiveTabIndex(tabs.length);
                   }}
@@ -411,24 +268,43 @@ export const TabbedObjectSearch = (props: TabbedObjectSearchProps) => {
             <TabOverview
               tab={activeTab || null}
               className="ml-2 md:ml-12 lg:ml-16"
-              onTabRename={(name) => onActiveTabChange({ name })}
+              onTabRename={(name) => modifyActiveTab({ name })}
               onTabDelete={deleteActiveTab}
             />
           </div>
           <div className="relative flex w-full grow overflow-hidden pl-2 pt-1 md:pl-6 md:pt-2 lg:pl-10">
             <MemoizedObjectSearch
-              key={activeTabIndex}
+              key={`${accountId}-${activeTab?.id || -1}`}
               {...props}
               initialFilters={activeTab?.filters}
               initialColumnState={activeTab?.columnsState}
               onStateChange={({ filters, columns: columnsState }) =>
-                onActiveTabChange({ filters, columnsState })
+                modifyActiveTab({ filters, columnsState })
               }
             />
           </div>
         </div>
       )}
-      {!tabs && !accountId && !isAccountLoading && (
+    </>
+  );
+};
+
+export const TabbedObjectSearchWithAccount = (
+  props: Omit<TabbedObjectSearchProps, "accountId">,
+) => {
+  const [creds] = useSkylarkCreds();
+  const { accountId, isLoading: isAccountLoading } = useUserAccount();
+
+  return (
+    <>
+      {accountId && !isAccountLoading && (
+        <TabbedObjectSearch
+          key={`${creds?.uri}-${accountId}`}
+          accountId={accountId}
+          {...props}
+        />
+      )}
+      {!accountId && !isAccountLoading && (
         <div className="flex h-full w-full flex-col items-center justify-center gap-4 text-base">
           <p className="text-3xl font-semibold">Something went wrong...</p>
           <p>We are having trouble accessing your Skylark Account ID.</p>

--- a/src/components/contentLibrary/tabbedObjectSearch/tabbedObjectSearch.test.tsx
+++ b/src/components/contentLibrary/tabbedObjectSearch/tabbedObjectSearch.test.tsx
@@ -14,7 +14,7 @@ import { GQLSkylarkAccountResponse } from "src/interfaces/skylark";
 
 import {
   ObjectSearchTab,
-  TabbedObjectSearch,
+  TabbedObjectSearchWithAccount,
 } from "./tabbedObjectSearch.component";
 
 const mockLocalStorage = (initialTabs?: ObjectSearchTab[]) => {
@@ -44,7 +44,7 @@ afterEach(() => {
 test("Loads the default tabs when localStorage is empty", async () => {
   mockLocalStorage();
 
-  render(<TabbedObjectSearch />);
+  render(<TabbedObjectSearchWithAccount />);
 
   await waitFor(() => {
     expect(screen.queryAllByText("Default View")).toHaveLength(2); // Length 2 as active
@@ -58,7 +58,7 @@ test("Loads the default tabs when localStorage is empty", async () => {
 test("Changing tabs", async () => {
   mockLocalStorage();
 
-  render(<TabbedObjectSearch />);
+  render(<TabbedObjectSearchWithAccount />);
 
   await waitFor(() => {
     expect(screen.queryAllByText("Default View")).toHaveLength(2); // Length 2 as active
@@ -75,7 +75,7 @@ test("Changing tabs", async () => {
 test("Rename active tab (save)", async () => {
   mockLocalStorage();
 
-  render(<TabbedObjectSearch />);
+  render(<TabbedObjectSearchWithAccount />);
 
   await waitFor(() => {
     expect(screen.queryAllByText("Default View")).toHaveLength(2); // Length 2 as active
@@ -104,7 +104,7 @@ test("Rename active tab (save)", async () => {
 test("Rename active tab (save with enter key)", async () => {
   mockLocalStorage();
 
-  render(<TabbedObjectSearch />);
+  render(<TabbedObjectSearchWithAccount />);
 
   await waitFor(() => {
     expect(screen.queryAllByText("Default View")).toHaveLength(2); // Length 2 as active
@@ -137,7 +137,7 @@ test("Rename active tab (save with enter key)", async () => {
 test("Rename active tab (cancel)", async () => {
   mockLocalStorage();
 
-  render(<TabbedObjectSearch />);
+  render(<TabbedObjectSearchWithAccount />);
 
   await waitFor(() => {
     expect(screen.queryAllByText("Default View")).toHaveLength(2); // Length 2 as active
@@ -166,7 +166,7 @@ test("Rename active tab (cancel)", async () => {
 test("Add new view", async () => {
   mockLocalStorage();
 
-  render(<TabbedObjectSearch />);
+  render(<TabbedObjectSearchWithAccount />);
 
   await waitFor(() => {
     expect(screen.queryAllByText("Default View")).toHaveLength(2); // Length 2 as active
@@ -218,7 +218,7 @@ test("Loads values from localStorage", async () => {
 
   mockLocalStorage(initialTabs);
 
-  render(<TabbedObjectSearch />);
+  render(<TabbedObjectSearchWithAccount />);
 
   await waitFor(() => {
     expect(screen.queryByText("Default View")).not.toBeInTheDocument();
@@ -248,7 +248,7 @@ test("Shows error message when Account ID can't be loaded", async () => {
     }),
   );
 
-  render(<TabbedObjectSearch />);
+  render(<TabbedObjectSearchWithAccount />);
 
   await waitFor(() => {
     expect(screen.getByText("Something went wrong...")).toBeInTheDocument();
@@ -272,7 +272,7 @@ describe("create button", () => {
   test("renders create button", async () => {
     mockLocalStorage();
 
-    render(<TabbedObjectSearch />);
+    render(<TabbedObjectSearchWithAccount />);
     await waitFor(() => {
       expect(screen.queryAllByText("Default View")).toHaveLength(2); // Length 2 as active
     });
@@ -289,7 +289,7 @@ describe("create button", () => {
   test("opens the create object modal", async () => {
     mockLocalStorage();
 
-    render(<TabbedObjectSearch />);
+    render(<TabbedObjectSearchWithAccount />);
 
     await waitFor(() => {
       expect(screen.queryAllByText("Default View")).toHaveLength(2); // Length 2 as active

--- a/src/components/contentLibrary/tabbedObjectSearch/tabbedObjectSearch.test.tsx
+++ b/src/components/contentLibrary/tabbedObjectSearch/tabbedObjectSearch.test.tsx
@@ -184,6 +184,56 @@ test("Add new view", async () => {
   expect(screen.queryAllByText("View 3")).toHaveLength(2);
 });
 
+test("Deletes active tab", async () => {
+  mockLocalStorage();
+
+  render(<TabbedObjectSearchWithAccount />);
+
+  await waitFor(() => {
+    expect(screen.queryAllByText("Default View")).toHaveLength(2); // Length 2 as active
+  });
+
+  const deleteActiveTabButton = screen.getByLabelText("Delete active tab");
+
+  fireEvent.click(deleteActiveTabButton);
+
+  expect(screen.queryAllByText("Default View")).toHaveLength(0);
+  expect(screen.queryAllByText("Availability")).toHaveLength(3);
+});
+
+test("Adds the initial tabs when all tabs are deleted", async () => {
+  mockLocalStorage([
+    {
+      id: "mytab",
+      name: "mytab",
+      filters: {
+        query: "GOT",
+        objectTypes: ["Episode"],
+        availability: {
+          dimensions: null,
+          timeTravel: null,
+        },
+      },
+    },
+  ]);
+
+  render(<TabbedObjectSearchWithAccount />);
+
+  await waitFor(() => {
+    expect(screen.queryAllByText("mytab")).toHaveLength(2); // Length 2 as active
+  });
+  expect(screen.queryAllByText("Default View")).toHaveLength(0);
+  expect(screen.queryAllByText("Availability")).toHaveLength(0);
+
+  const deleteActiveTabButton = screen.getByLabelText("Delete active tab");
+
+  fireEvent.click(deleteActiveTabButton);
+
+  expect(screen.queryAllByText("Default View")).toHaveLength(2);
+  expect(screen.queryAllByText("Availability")).toHaveLength(1);
+  expect(screen.queryAllByText("mytab")).toHaveLength(0);
+});
+
 test("Loads values from localStorage", async () => {
   const initialTabs: ObjectSearchTab[] = [
     {

--- a/src/components/inputs/select/languageSelect/languageSelect.component.tsx
+++ b/src/components/inputs/select/languageSelect/languageSelect.component.tsx
@@ -7,6 +7,7 @@ import {
   SelectProps,
 } from "src/components/inputs/select";
 import { useUser } from "src/contexts/useUser";
+import { useUserAccount } from "src/hooks/useUserAccount";
 
 // Downloaded from https://datahub.io/core/language-codes "ietf-language-tags"
 import IetfLanguageTags from "./ietf-language-tags.json";
@@ -36,7 +37,8 @@ export const LanguageSelect = ({
   onChange,
   ...props
 }: LanguageSelectProps) => {
-  const { usedLanguages, defaultLanguage } = useUser();
+  const { usedLanguages } = useUser();
+  const { defaultLanguage } = useUserAccount();
 
   useEffect(() => {
     if (

--- a/src/components/modals/betaReleaseAuthModal/betaReleaseAuthModal.component.tsx
+++ b/src/components/modals/betaReleaseAuthModal/betaReleaseAuthModal.component.tsx
@@ -4,19 +4,17 @@ import clsx from "clsx";
 import { usePlausible } from "next-plausible";
 import React, { useEffect, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
-import { useEffectOnce, useLocalStorage } from "usehooks-ts";
 
 import { Button } from "src/components/button";
 import { CopyToClipboard } from "src/components/copyToClipboard/copyToClipboard.component";
 import { FiX } from "src/components/icons";
 import { TextInput } from "src/components/inputs/textInput";
-import { LOCAL_STORAGE } from "src/constants/localStorage";
 import { QueryKeys } from "src/enums/graphql";
+import { useSkylarkCreds } from "src/hooks/localStorage/useCreds";
 import {
   SkylarkCreds,
   useConnectedToSkylark,
 } from "src/hooks/useConnectedToSkylark";
-import { useCredsFromLocalStorage } from "src/hooks/useCredsFromLocalStorage";
 import { useUserAccount } from "src/hooks/useUserAccount";
 
 interface AddAuthTokenModalProps {
@@ -34,9 +32,9 @@ export const AddAuthTokenModal = ({
   const { isConnected, isLoading, invalidUri, invalidToken, setCreds } =
     useConnectedToSkylark();
 
-  const { account } = useUserAccount();
+  const { accountId } = useUserAccount();
 
-  const [credsFromLocalStorage, saveCreds] = useCredsFromLocalStorage();
+  const [credsFromLocalStorage, saveCreds] = useSkylarkCreds();
 
   const [{ uri: inputUri, token: inputToken }, setInputCreds] =
     useState<SkylarkCreds>({ uri: "", token: "" });
@@ -53,10 +51,7 @@ export const AddAuthTokenModal = ({
     }
   }, 750);
 
-  if (
-    (!isOpen && !isLoading && !isConnected) ||
-    (!isOpen && (!debouncedUri || !debouncedToken))
-  ) {
+  if (!isOpen && !isLoading && !isConnected) {
     setIsOpen(true);
   }
 
@@ -80,14 +75,13 @@ export const AddAuthTokenModal = ({
         uri: debouncedUri,
         token: debouncedToken,
       });
+      setCreds(null);
 
       queryClient.clear();
+      await queryClient.invalidateQueries();
       await queryClient.refetchQueries({
-        queryKey: [QueryKeys.Schema],
-        type: "active",
-      });
-      await queryClient.refetchQueries({
-        queryKey: [QueryKeys.AccountStatus],
+        queryKey: [QueryKeys.Account],
+        type: "all",
       });
 
       setIsOpen(false);
@@ -128,15 +122,15 @@ export const AddAuthTokenModal = ({
             Enter your GraphQL URI and API Key below to connect to your Skylark
             account.
           </Dialog.Description>
-          {account?.accountId && (
+          {accountId && (
             <div className="mt-2 flex items-center">
               <p>
                 Currently connected to:{" "}
                 <code className="rounded-sm bg-manatee-200 p-1">
-                  {account?.accountId}
+                  {accountId}
                 </code>
               </p>
-              <CopyToClipboard value={account?.accountId} />
+              <CopyToClipboard value={accountId} />
             </div>
           )}
           <div className="my-4 flex flex-col space-y-2 md:my-10">
@@ -172,7 +166,9 @@ export const AddAuthTokenModal = ({
                 requestLoading && "border-warning",
                 !requestLoading &&
                   debouncedUri &&
-                  (invalidToken ? "border-error" : "border-success"),
+                  (invalidToken || debouncedToken === ""
+                    ? "border-error"
+                    : "border-success"),
               )}
               withCopy
             />

--- a/src/components/modals/graphQLQueryModal/graphQLQueryModal.component.tsx
+++ b/src/components/modals/graphQLQueryModal/graphQLQueryModal.component.tsx
@@ -5,6 +5,7 @@ import dynamic from "next/dynamic";
 import { useMemo, useState } from "react";
 import { FiCopy } from "react-icons/fi";
 import { GrGraphQl } from "react-icons/gr";
+import { v4 as uuidv4 } from "uuid";
 
 import { Button } from "src/components/button";
 import { FiX, Spinner } from "src/components/icons";
@@ -73,7 +74,7 @@ const updateGraphiQLLocalStorage = (
   const operationName = operation && operation.name?.value;
 
   const newTab: GraphiQLTabStateTab = {
-    id: "dynamically-generated-query",
+    id: uuidv4(),
     hash: null,
     operationName: operationName || "",
     query: formattedQuery,

--- a/src/components/modals/graphQLQueryModal/graphQLQueryModal.test.tsx
+++ b/src/components/modals/graphQLQueryModal/graphQLQueryModal.test.tsx
@@ -7,6 +7,8 @@ import { GET_SKYLARK_OBJECT_TYPES } from "src/lib/graphql/skylark/queries";
 
 import { DisplayGraphQLQuery } from "./graphQLQueryModal.component";
 
+jest.mock("uuid", () => ({ v4: () => "dynamically-generated-query" }));
+
 const label = "Schema";
 
 const variables = {

--- a/src/components/modals/searchObjectsModal/searchObjectsModal.test.tsx
+++ b/src/components/modals/searchObjectsModal/searchObjectsModal.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor, screen, fireEvent, prettyDOM } from "@testing-library/react";
+import { waitFor, screen, fireEvent } from "@testing-library/react";
 
 import GQLGameOfThronesSearchResultsPage1enGB from "src/__tests__/fixtures/skylark/queries/search/gotPage1enGB.json";
 import { render } from "src/__tests__/utils/test-utils";

--- a/src/components/navigation/navigation/navigation.component.tsx
+++ b/src/components/navigation/navigation/navigation.component.tsx
@@ -14,8 +14,8 @@ import { AddAuthTokenModal } from "src/components/modals";
 import { Hamburger } from "src/components/navigation/hamburger";
 import { NavigationLinks } from "src/components/navigation/links";
 import { UserAvatar } from "src/components/user";
+import { useSkylarkCreds } from "src/hooks/localStorage/useCreds";
 import { useAccountStatus } from "src/hooks/useAccountStatus";
-import { useCredsFromLocalStorage } from "src/hooks/useCredsFromLocalStorage";
 
 import Logo from "public/images/skylark.png";
 
@@ -66,7 +66,7 @@ export const Navigation = () => {
 
   const [isAuthModalOpen, setAuthModalOpen] = useState(false);
 
-  const [creds] = useCredsFromLocalStorage();
+  const [creds] = useSkylarkCreds();
   const customerIdentifier = isClient
     ? getCustomerIdentifier(creds?.uri || "")
     : "";

--- a/src/components/navigation/navigation/navigation.component.tsx
+++ b/src/components/navigation/navigation/navigation.component.tsx
@@ -2,10 +2,10 @@ import { Menu } from "@headlessui/react";
 import clsx from "clsx";
 import Image from "next/image";
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { FiLogOut } from "react-icons/fi";
 import { sentenceCase } from "sentence-case";
-import { useIsClient, useLocalStorage, useReadLocalStorage } from "usehooks-ts";
+import { useIsClient } from "usehooks-ts";
 
 import { AccountStatus } from "src/components/account";
 import { Button } from "src/components/button";

--- a/src/components/objectSearch/objectSearch.component.tsx
+++ b/src/components/objectSearch/objectSearch.component.tsx
@@ -12,9 +12,9 @@ import { useEffect, useState, useMemo, memo, useCallback } from "react";
 
 import { Spinner } from "src/components/icons";
 import { OBJECT_LIST_TABLE } from "src/constants/skylark";
-import { useUser } from "src/contexts/useUser";
 import { SearchFilters, useSearch } from "src/hooks/useSearch";
 import { useSkylarkObjectTypes } from "src/hooks/useSkylarkObjectTypes";
+import { useUserAccount } from "src/hooks/useUserAccount";
 import { SkylarkObjectIdentifier } from "src/interfaces/skylark";
 import {
   hasProperty,
@@ -96,7 +96,8 @@ const handleUpdater = function <T>(updater: Updater<T>, prevValue: T) {
 };
 
 export const ObjectSearch = (props: ObjectSearchProps) => {
-  const { defaultLanguage, isLoading: isUserLoading } = useUser();
+  const { defaultLanguage, isLoading: isUserLoading } = useUserAccount();
+
   const {
     setPanelObject,
     isPanelOpen,

--- a/src/components/objectSearch/objectSearch.test.tsx
+++ b/src/components/objectSearch/objectSearch.test.tsx
@@ -6,7 +6,6 @@ import { server } from "src/__tests__/mocks/server";
 import {
   act,
   fireEvent,
-  prettyDOM,
   render,
   screen,
   waitFor,

--- a/src/components/objectSearch/results/columnConfiguration.tsx
+++ b/src/components/objectSearch/results/columnConfiguration.tsx
@@ -144,13 +144,13 @@ const objectTypeIndicatorColumn = columnHelper.display({
   maxSize: 0,
   minSize: 0,
   cell: ({ cell, row }) => {
-    const original = row.original as ParsedSkylarkObject;
-    const cellContext = cell.getContext();
+    // const original = row.original as ParsedSkylarkObject;
+    // const cellContext = cell.getContext();
 
-    const { config }: { config: ParsedSkylarkObjectConfig | null } =
-      cellContext.table.options.meta?.objectTypesWithConfig?.find(
-        ({ objectType }) => objectType === original.objectType,
-      ) || { config: null };
+    // const { config }: { config: ParsedSkylarkObjectConfig | null } =
+    //   cellContext.table.options.meta?.objectTypesWithConfig?.find(
+    //     ({ objectType }) => objectType === original.objectType,
+    //   ) || { config: null };
 
     return (
       // <div

--- a/src/contexts/useUser.tsx
+++ b/src/contexts/useUser.tsx
@@ -1,11 +1,6 @@
 import { createContext, ReactNode, useContext, useReducer } from "react";
 
 import { LOCAL_STORAGE } from "src/constants/localStorage";
-import { useUserAccount } from "src/hooks/useUserAccount";
-import {
-  SkylarkAccount,
-  SkylarkUser,
-} from "src/interfaces/skylark/environment";
 import { getJSONFromLocalStorage } from "src/lib/utils";
 
 type State = {
@@ -14,16 +9,11 @@ type State = {
 type Action = { type: "addUsedLanguages"; value: string[] };
 type Dispatch = (action: Action) => void;
 
-const UserContext = createContext<
-  | {
-      state: State;
-      account?: SkylarkAccount;
-      user?: SkylarkUser;
-      isLoading: boolean;
-      dispatch: Dispatch;
-    }
-  | undefined
->(undefined);
+type UserContextType = {
+  dispatch: Dispatch;
+} & State;
+
+const UserContext = createContext<UserContextType | undefined>(undefined);
 
 const userReducer = (state: State, action: Action) => {
   switch (action.type) {
@@ -60,10 +50,13 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
         : [],
   });
 
-  const { account, user, isLoading } = useUserAccount();
-
   return (
-    <UserContext.Provider value={{ state, account, user, isLoading, dispatch }}>
+    <UserContext.Provider
+      value={{
+        ...state,
+        dispatch,
+      }}
+    >
       {children}
     </UserContext.Provider>
   );
@@ -75,16 +68,5 @@ export const useUser = () => {
     throw new Error("useUser must be used within a UserProvider");
   }
 
-  const { state, account, user, dispatch, isLoading } = context;
-
-  return {
-    ...state,
-    accountId: account?.accountId || user?.account,
-    // In the future a user will have their own custom default language
-    defaultLanguage: account?.defaultLanguage,
-    permissions: user?.permissions,
-    role: user?.role,
-    isLoading,
-    dispatch,
-  };
+  return context;
 };

--- a/src/hooks/availability/useAvailabilityDimensionWithValues.tsx
+++ b/src/hooks/availability/useAvailabilityDimensionWithValues.tsx
@@ -51,7 +51,7 @@ export const useAvailabilityDimensionsWithValues = () => {
         return skylarkRequest("query", query as DocumentNode);
       },
       getNextPageParam,
-      enabled: !!dimensionsWithoutValues,
+      enabled: dimensionsWithoutValues && dimensionsWithoutValues.length > 0,
     });
 
   // This if statement ensures that all data is fetched

--- a/src/hooks/localStorage/useCreds.tsx
+++ b/src/hooks/localStorage/useCreds.tsx
@@ -2,10 +2,9 @@ import { Dispatch, useEffect } from "react";
 import { useLocalStorage } from "usehooks-ts";
 
 import { LOCAL_STORAGE } from "src/constants/localStorage";
+import { SkylarkCreds } from "src/hooks/useConnectedToSkylark";
 
-import { SkylarkCreds } from "./useConnectedToSkylark";
-
-export const useCredsFromLocalStorage = (): [
+export const useSkylarkCreds = (): [
   SkylarkCreds | null,
   Dispatch<SkylarkCreds | null>,
 ] => {
@@ -22,8 +21,8 @@ export const useCredsFromLocalStorage = (): [
       setCreds({ uri: oldUri || "", token: oldToken || "" });
 
       // TODO remove in future
-      // localStorage.removeItem(LOCAL_STORAGE.betaAuth.uri);
-      // localStorage.removeItem(LOCAL_STORAGE.betaAuth.token);
+      localStorage.removeItem(LOCAL_STORAGE.betaAuth.uri);
+      localStorage.removeItem(LOCAL_STORAGE.betaAuth.token);
     }
   }, [creds, setCreds]);
 

--- a/src/hooks/localStorage/useObjectSearchTabs.tsx
+++ b/src/hooks/localStorage/useObjectSearchTabs.tsx
@@ -4,6 +4,7 @@ import { useDebouncedCallback } from "use-debounce";
 import { ObjectSearchInitialColumnsState } from "src/components/objectSearch";
 import { LOCAL_STORAGE } from "src/constants/localStorage";
 import { SearchFilters } from "src/hooks/useSearch";
+import { readIntFromLocalStorage } from "src/lib/utils";
 
 export interface ObjectSearchTab {
   id: string;
@@ -62,20 +63,6 @@ const readTabsFromStorage = (accountId: string) => {
     return JSON.parse(valueFromStorage) as ObjectSearchTab[];
   } catch (err) {
     return null;
-  }
-};
-
-const readIntFromLocalStorage = (name: string): number => {
-  const valueFromStorage = localStorage.getItem(name);
-
-  if (!valueFromStorage) {
-    return 0;
-  }
-
-  try {
-    return parseInt(valueFromStorage);
-  } catch (err) {
-    return 0;
   }
 };
 

--- a/src/hooks/localStorage/useObjectSearchTabs.tsx
+++ b/src/hooks/localStorage/useObjectSearchTabs.tsx
@@ -1,0 +1,193 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useDebouncedCallback } from "use-debounce";
+
+import { ObjectSearchInitialColumnsState } from "src/components/objectSearch";
+import { LOCAL_STORAGE } from "src/constants/localStorage";
+import { SearchFilters } from "src/hooks/useSearch";
+
+export interface ObjectSearchTab {
+  id: string;
+  name?: string;
+  filters: SearchFilters;
+  columnsState?: ObjectSearchInitialColumnsState;
+}
+
+const saveTabStateToStorage = (
+  accountId: string,
+  {
+    tabs,
+    activeTabIndex,
+    tabsScrollPosition,
+  }: Partial<{
+    tabs: ObjectSearchTab[];
+    activeTabIndex: number;
+    tabsScrollPosition: number;
+  }>,
+) => {
+  if (accountId) {
+    if (tabs !== undefined) {
+      localStorage.setItem(
+        LOCAL_STORAGE.accountPrefixed(accountId).contentLibrary.tabState,
+        JSON.stringify(tabs),
+      );
+    }
+
+    if (activeTabIndex !== undefined) {
+      localStorage.setItem(
+        LOCAL_STORAGE.accountPrefixed(accountId).contentLibrary.activeTabIndex,
+        String(activeTabIndex),
+      );
+    }
+
+    if (tabsScrollPosition !== undefined) {
+      localStorage.setItem(
+        LOCAL_STORAGE.accountPrefixed(accountId).contentLibrary
+          .tabsScrollPosition,
+        String(tabsScrollPosition),
+      );
+    }
+  }
+};
+
+const readTabsFromStorage = (accountId: string) => {
+  const valueFromStorage = localStorage.getItem(
+    LOCAL_STORAGE.accountPrefixed(accountId).contentLibrary.tabState,
+  );
+
+  if (!valueFromStorage) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(valueFromStorage) as ObjectSearchTab[];
+  } catch (err) {
+    return null;
+  }
+};
+
+const readIntFromLocalStorage = (name: string): number => {
+  const valueFromStorage = localStorage.getItem(name);
+
+  if (!valueFromStorage) {
+    return 0;
+  }
+
+  try {
+    return parseInt(valueFromStorage);
+  } catch (err) {
+    return 0;
+  }
+};
+
+export const useObjectSearchTabs = (
+  accountId: string,
+  initialTabs: ObjectSearchTab[],
+) => {
+  const [activeTabIndex, setActiveTabIndex] = useState(0);
+  const [tabs, setTabs] = useState<ObjectSearchTab[] | undefined>(undefined);
+  const [initialTabsScrollPosition, setInitialTabsScrollPosition] = useState(0);
+
+  useEffect(() => {
+    const setValuesFromLocalStorage = () => {
+      if (accountId) {
+        const tabsFromStorage = readTabsFromStorage(accountId);
+        const activeIndex = readIntFromLocalStorage(
+          LOCAL_STORAGE.accountPrefixed(accountId).contentLibrary
+            .activeTabIndex,
+        );
+        const tabsScrollPosition = readIntFromLocalStorage(
+          LOCAL_STORAGE.accountPrefixed(accountId).contentLibrary
+            .tabsScrollPosition,
+        );
+
+        setTabs(
+          tabsFromStorage && tabsFromStorage.length > 0
+            ? tabsFromStorage
+            : initialTabs,
+        );
+        setActiveTabIndex(
+          tabsFromStorage && activeIndex && activeIndex < tabsFromStorage.length
+            ? activeIndex
+            : 0,
+        );
+        setInitialTabsScrollPosition(tabsScrollPosition || 0);
+      } else {
+        setTabs(undefined);
+        setActiveTabIndex(0);
+        setInitialTabsScrollPosition(0);
+      }
+    };
+
+    setValuesFromLocalStorage();
+
+    window.addEventListener("storage", setValuesFromLocalStorage);
+    return () => {
+      window.removeEventListener("storage", setValuesFromLocalStorage);
+    };
+  }, [accountId, initialTabs]);
+
+  const modifyActiveTab = useCallback(
+    (updatedTab: Partial<ObjectSearchTab>) => {
+      const updatedTabs =
+        tabs?.map((tab, index) => {
+          if (index !== activeTabIndex) return tab;
+
+          return {
+            ...tab,
+            ...{
+              ...updatedTab,
+              columnsState: updatedTab.columnsState || tab.columnsState,
+              filters: updatedTab.filters || tab.filters,
+            },
+          };
+        }) || [];
+
+      saveTabStateToStorage(accountId, { tabs: updatedTabs });
+      setTabs(updatedTabs);
+    },
+    [accountId, activeTabIndex, setTabs, tabs],
+  );
+
+  const deleteActiveTab = useCallback(() => {
+    if (tabs) {
+      const updatedTabs = [...tabs];
+      updatedTabs.splice(activeTabIndex, 1);
+
+      if (updatedTabs.length === 0) {
+        updatedTabs.push(...initialTabs);
+      }
+
+      saveTabStateToStorage(accountId, { tabs: updatedTabs });
+      setTabs(updatedTabs);
+      setActiveTabIndex(activeTabIndex > 0 ? activeTabIndex - 1 : 0);
+    }
+  }, [accountId, activeTabIndex, initialTabs, tabs]);
+
+  const changeActiveTabIndex = (newIndex: number) => {
+    if (accountId) {
+      saveTabStateToStorage(accountId, { activeTabIndex: newIndex });
+    }
+    setActiveTabIndex(newIndex);
+  };
+
+  const saveScrollPosition = useDebouncedCallback((position: number) => {
+    saveTabStateToStorage(accountId, { tabsScrollPosition: position });
+  }, 500);
+
+  const activeTab = useMemo(
+    () => tabs?.[activeTabIndex],
+    [activeTabIndex, tabs],
+  );
+
+  return {
+    activeTab,
+    tabs,
+    initialTabsScrollPosition,
+    setActiveTabIndex,
+    setTabs,
+    saveScrollPosition,
+    deleteActiveTab,
+    modifyActiveTab,
+    changeActiveTabIndex,
+  };
+};

--- a/src/hooks/objects/get/useGetObjectContent.tsx
+++ b/src/hooks/objects/get/useGetObjectContent.tsx
@@ -154,8 +154,9 @@ export const useGetObjectContent = (
 
   const content = useMemo(() => {
     const contentObjects =
-      data?.pages?.flatMap((page) => page.getObjectContent.content.objects) ||
-      [];
+      data?.pages?.flatMap(
+        (page) => page.getObjectContent.content?.objects || [],
+      ) || [];
 
     const parsedContent = parseObjectContent({ objects: contentObjects });
     return parsedContent;

--- a/src/hooks/useAccountStatus.tsx
+++ b/src/hooks/useAccountStatus.tsx
@@ -1,18 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
-import request from "graphql-request";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback } from "react";
 
-import { LOCAL_STORAGE } from "src/constants/localStorage";
-import {
-  REQUEST_HEADERS,
-  SAAS_API_ENDPOINT,
-  SAAS_API_KEY,
-} from "src/constants/skylark";
 import { QueryKeys } from "src/enums/graphql";
-import { GQLSkylarkObjectTypesResponse } from "src/interfaces/graphql/introspection";
 import {
-  GQLSkylarkActivationStatusResponse,
-  GQLSkylarkBackgroundTask,
   GQLSkylarkErrorResponse,
   GQLSkylarkStatusResponse,
 } from "src/interfaces/skylark";

--- a/src/hooks/useConnectedToSkylark.tsx
+++ b/src/hooks/useConnectedToSkylark.tsx
@@ -1,14 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import request from "graphql-request";
 import { useEffect, useState } from "react";
-import { useReadLocalStorage } from "usehooks-ts";
 
-import { LOCAL_STORAGE } from "src/constants/localStorage";
-import {
-  REQUEST_HEADERS,
-  SAAS_API_ENDPOINT,
-  SAAS_API_KEY,
-} from "src/constants/skylark";
+import { REQUEST_HEADERS } from "src/constants/skylark";
 import { GQLSkylarkObjectTypesResponse } from "src/interfaces/graphql/introspection";
 import { GET_SKYLARK_OBJECT_TYPES } from "src/lib/graphql/skylark/queries";
 
@@ -18,23 +12,6 @@ export interface SkylarkCreds {
   uri: string;
   token: string;
 }
-
-/**
- * 
- * @returns   if (withDevelopmentDefault) {
-    const { origin } = window.location;
-    // Timesaving in development to connect to sl-develop-10 when available unless in Storybook.
-    const useDevelopmentDefaults =
-      (origin.includes("http://localhost") &&
-        !origin.includes("http://localhost:6006")) ||
-      origin.includes("vercel.app");
-
-    if (useDevelopmentDefaults) {
-      fallbackUri = SAAS_API_ENDPOINT || null;
-      fallbackToken = SAAS_API_KEY || null;
-    }
-  }
- */
 
 export const useConnectedToSkylark = () => {
   const [overrideCreds, setOverrideCreds] = useState<SkylarkCreds | null>(null);

--- a/src/hooks/useSkylarkSchemaIntrospection.tsx
+++ b/src/hooks/useSkylarkSchemaIntrospection.tsx
@@ -10,6 +10,8 @@ import { QueryKeys } from "src/enums/graphql";
 import { skylarkRequest } from "src/lib/graphql/skylark/client";
 import { SKYLARK_SCHEMA_INTROSPECTION_QUERY } from "src/lib/graphql/skylark/queries";
 
+import { useSkylarkCreds } from "./localStorage/useCreds";
+
 export const selectSchema = (data: IntrospectionQuery) => data.__schema;
 
 export const useSkylarkSchemaIntrospection = <
@@ -18,8 +20,15 @@ export const useSkylarkSchemaIntrospection = <
 >(
   select?: (data: IntrospectionQuery) => TData,
 ) => {
+  const [creds] = useSkylarkCreds();
+
   const { data, isError } = useQuery<IntrospectionQuery, Error, TData>({
-    queryKey: [QueryKeys.Schema, SKYLARK_SCHEMA_INTROSPECTION_QUERY],
+    // refetch when creds.uri changes
+    queryKey: [
+      QueryKeys.Schema,
+      SKYLARK_SCHEMA_INTROSPECTION_QUERY,
+      creds?.uri,
+    ],
     queryFn: async () =>
       skylarkRequest(
         "query",

--- a/src/hooks/useUserAccount.tsx
+++ b/src/hooks/useUserAccount.tsx
@@ -12,22 +12,27 @@ import {
 import { skylarkRequest } from "src/lib/graphql/skylark/client";
 import { GET_USER_AND_ACCOUNT } from "src/lib/graphql/skylark/queries";
 
-const select = (
-  data: GQLSkylarkUserAndAccountResponse,
-): { account: SkylarkAccount; user: SkylarkUser } => ({
-  account: {
-    accountId: data?.getAccount.account_id,
-    skylarkVersion: data?.getAccount.skylark_version,
-    defaultLanguage: data?.getAccount.config?.default_language,
-  },
-  user: data.getUser,
+type UseUserAccount = {
+  accountId?: SkylarkAccount["accountId"];
+  skylarkVersion?: SkylarkAccount["skylarkVersion"];
+  defaultLanguage?: SkylarkAccount["defaultLanguage"];
+  permissions?: SkylarkUser["permissions"];
+  role?: SkylarkUser["role"];
+};
+
+const select = (data: GQLSkylarkUserAndAccountResponse): UseUserAccount => ({
+  accountId: data?.getAccount.account_id || data.getUser.account,
+  skylarkVersion: data?.getAccount.skylark_version,
+  defaultLanguage: data?.getAccount.config?.default_language,
+  permissions: data.getUser.permissions,
+  role: data.getUser.role,
 });
 
 export const useUserAccount = () => {
   const { data, isLoading } = useQuery<
     GQLSkylarkUserAndAccountResponse,
     GQLSkylarkErrorResponse<GQLSkylarkUserAndAccountResponse>,
-    { account: SkylarkAccount; user: SkylarkUser }
+    UseUserAccount
   >({
     queryKey: [QueryKeys.Account, GET_USER_AND_ACCOUNT],
     queryFn: async () => skylarkRequest("query", GET_USER_AND_ACCOUNT),
@@ -35,8 +40,7 @@ export const useUserAccount = () => {
   });
 
   return {
-    account: data?.account,
-    user: data?.user,
+    ...data,
     isLoading,
   };
 };

--- a/src/interfaces/skylark/responses.ts
+++ b/src/interfaces/skylark/responses.ts
@@ -104,7 +104,7 @@ export interface GQLSkylarkGetObjectRelationshipsResponse {
 
 export interface GQLSkylarkGetObjectContentResponse {
   getObjectContent: {
-    content: SkylarkGraphQLObjectContent;
+    content: SkylarkGraphQLObjectContent | null;
   };
 }
 

--- a/src/lib/utils/utils.test.ts
+++ b/src/lib/utils/utils.test.ts
@@ -5,12 +5,14 @@ import {
   addCloudinaryOnTheFlyImageTransformation,
   createAccountIdentifier,
   formatObjectField,
+  getJSONFromLocalStorage,
   getObjectDisplayName,
   getPrimaryKeyField,
   hasProperty,
   isObject,
   isObjectsDeepEqual,
   pause,
+  readIntFromLocalStorage,
 } from "./utils";
 
 describe("hasProperty", () => {
@@ -255,5 +257,54 @@ describe("addCloudinaryOnTheFlyImageTransformation", () => {
     expect(got).toEqual(
       "https://res.cloudinary.com/test/image/fetch/h_40,w_20,c_fill/https://skylark.com",
     );
+  });
+});
+
+describe("getJSONFromLocalStorage", () => {
+  test("parses JSON from LocalStorage", () => {
+    Storage.prototype.getItem = jest
+      .fn()
+      .mockImplementation(() => '{"key": "value"}');
+
+    const got = getJSONFromLocalStorage("key");
+    console.log(got);
+    expect(got).toStrictEqual({ key: "value" });
+  });
+
+  test("returns null when the value cannot be parsed", () => {
+    Storage.prototype.getItem = jest.fn().mockImplementation(() => "string");
+
+    const got = getJSONFromLocalStorage("key");
+    expect(got).toBe(null);
+  });
+
+  test("returns null when the key does not exist", () => {
+    Storage.prototype.getItem = jest.fn().mockImplementation(() => null);
+
+    const got = getJSONFromLocalStorage("key");
+    expect(got).toBe(null);
+  });
+});
+
+describe("readIntFromLocalStorage", () => {
+  test("reads an int from LocalStorage", () => {
+    Storage.prototype.getItem = jest.fn().mockImplementation(() => "6");
+
+    const got = readIntFromLocalStorage("key");
+    expect(got).toBe(6);
+  });
+
+  test("returns 0 when the value cannot be converted to an int", () => {
+    Storage.prototype.getItem = jest.fn().mockImplementation(() => "string");
+
+    const got = readIntFromLocalStorage("key");
+    expect(got).toBe(0);
+  });
+
+  test("returns 0 when the key does not exist", () => {
+    Storage.prototype.getItem = jest.fn().mockImplementation(() => null);
+
+    const got = readIntFromLocalStorage("key");
+    expect(got).toBe(0);
   });
 });

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -150,6 +150,21 @@ export const getJSONFromLocalStorage = <T>(key: string) => {
   }
 };
 
+export const readIntFromLocalStorage = (name: string): number => {
+  const valueFromStorage = localStorage.getItem(name);
+
+  if (!valueFromStorage) {
+    return 0;
+  }
+
+  try {
+    const int = parseInt(valueFromStorage);
+    return Number.isNaN(int) ? 0 : int;
+  } catch (err) {
+    return 0;
+  }
+};
+
 export const addCloudinaryOnTheFlyImageTransformation = (
   imageUrl: string,
   opts: { height?: number; width?: number },

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,6 +10,7 @@ import PlausibleProvider from "next-plausible";
 import type { AppProps } from "next/app";
 import Head from "next/head";
 import Script from "next/script";
+import { useState } from "react";
 import "react-toastify/dist/ReactToastify.css";
 
 import { Navigation } from "src/components/navigation";
@@ -25,7 +26,7 @@ const loadFramerMotionFeatures = () =>
   );
 
 export default function App({ Component, pageProps }: AppProps) {
-  const queryClient = createSkylarkReactQueryClient();
+  const [queryClient] = useState(createSkylarkReactQueryClient);
 
   return (
     <PlausibleProvider domain={APP_URL} enabled={!!APP_URL}>

--- a/src/pages/beta/connect.tsx
+++ b/src/pages/beta/connect.tsx
@@ -2,13 +2,13 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 
-import { useCredsFromLocalStorage } from "src/hooks/useCredsFromLocalStorage";
+import { useSkylarkCreds } from "src/hooks/localStorage/useCreds";
 
 export default function BetaConnect() {
   const { query, push: navigateTo } = useRouter();
   const queryClient = useQueryClient();
 
-  const [, saveCreds] = useCredsFromLocalStorage();
+  const [, saveCreds] = useSkylarkCreds();
 
   useEffect(() => {
     if (query.uri && query.apikey) {

--- a/src/pages/developer/graphql-editor.tsx
+++ b/src/pages/developer/graphql-editor.tsx
@@ -5,8 +5,8 @@ import { useReadLocalStorage } from "usehooks-ts";
 import { DEFAULT_QUERY } from "src/components/graphiqlEditor/graphiqlEditor.component";
 import { Spinner } from "src/components/icons";
 import { LOCAL_STORAGE } from "src/constants/localStorage";
+import { useSkylarkCreds } from "src/hooks/localStorage/useCreds";
 import { useConnectedToSkylark } from "src/hooks/useConnectedToSkylark";
-import { useCredsFromLocalStorage } from "src/hooks/useCredsFromLocalStorage";
 
 const DynamicGraphiQLEditor = dynamic(
   () =>
@@ -26,7 +26,7 @@ export default function GraphQLQueryEditor() {
   const { isConnected } = useConnectedToSkylark();
   const [defaultQuery, setDefaultQuery] = useState(DEFAULT_QUERY);
 
-  const [creds] = useCredsFromLocalStorage();
+  const [creds] = useSkylarkCreds();
 
   useEffect(() => {
     // Default to light theme https://github.com/graphql/graphiql/issues/2924

--- a/src/pages/developer/graphql-editor.tsx
+++ b/src/pages/developer/graphql-editor.tsx
@@ -1,6 +1,6 @@
 import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";
-import { useReadLocalStorage } from "usehooks-ts";
+import { useIsClient, useReadLocalStorage } from "usehooks-ts";
 
 import { DEFAULT_QUERY } from "src/components/graphiqlEditor/graphiqlEditor.component";
 import { Spinner } from "src/components/icons";
@@ -25,6 +25,7 @@ const DynamicGraphiQLEditor = dynamic(
 export default function GraphQLQueryEditor() {
   const { isConnected } = useConnectedToSkylark();
   const [defaultQuery, setDefaultQuery] = useState(DEFAULT_QUERY);
+  const isClient = useIsClient();
 
   const [creds] = useSkylarkCreds();
 
@@ -56,7 +57,7 @@ export default function GraphQLQueryEditor() {
 
   return (
     <div className="pt-nav h-full w-full">
-      {isConnected && creds?.uri && creds.token && (
+      {isClient && isConnected && creds?.uri && creds.token && (
         <DynamicGraphiQLEditor
           uri={creds.uri}
           token={creds.token}

--- a/src/pages/import/csv.tsx
+++ b/src/pages/import/csv.tsx
@@ -1,11 +1,9 @@
 import { useState, useReducer, useEffect } from "react";
 import { FiDownload, FiUpload } from "react-icons/fi";
-import { useReadLocalStorage } from "usehooks-ts";
 
 import { Button } from "src/components/button";
 import { ObjectTypeSelect } from "src/components/inputs/select";
 import { StatusCard, statusType } from "src/components/statusCard";
-import { LOCAL_STORAGE } from "src/constants/localStorage";
 import { useSkylarkCreds } from "src/hooks/localStorage/useCreds";
 import { useSkylarkObjectOperations } from "src/hooks/useSkylarkObjectTypes";
 import {

--- a/src/pages/import/csv.tsx
+++ b/src/pages/import/csv.tsx
@@ -6,7 +6,7 @@ import { Button } from "src/components/button";
 import { ObjectTypeSelect } from "src/components/inputs/select";
 import { StatusCard, statusType } from "src/components/statusCard";
 import { LOCAL_STORAGE } from "src/constants/localStorage";
-import { useCredsFromLocalStorage } from "src/hooks/useCredsFromLocalStorage";
+import { useSkylarkCreds } from "src/hooks/localStorage/useCreds";
 import { useSkylarkObjectOperations } from "src/hooks/useSkylarkObjectTypes";
 import {
   ApiRouteFlatfileImportRequestBody,
@@ -169,7 +169,7 @@ export default function CSVImportPage() {
     numErrored: 0,
   });
 
-  const [creds] = useCredsFromLocalStorage();
+  const [creds] = useSkylarkCreds();
 
   const createObjectsInSkylark = async (batchId: string) => {
     dispatch({ stage: "import", status: statusType.success });


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->

Tabbed Object Search:
- Refetch when account changes
- Move object tab logic to custom hook to make it easier to manage

Also:
- Add useLocalStorage hook for creds, move to a single LocalStorage value
- Refetch Schema when `URI` changes

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Refactoring
