### PR TITLE
fix: reduce flakiness of Cypress and Percy tests

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -18,6 +18,7 @@ jobs:
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      - run: yarn
       - run: yarn build
       - name: Save build folder
         uses: actions/upload-artifact@v3

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -18,7 +18,12 @@ jobs:
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-      - run: yarn
+      # Install yarn dependencies and cache for later
+      # pass runTests: false to the Cypress GitHub Action to instruct it only to install and cache Cypress and npm dependencies without running the tests
+      # https://docs.cypress.io/guides/continuous-integration/github-actions#Parallelization
+      - uses: cypress-io/github-action@v4
+        with:
+          runTests: false
       - run: yarn build
       - name: Save build folder
         uses: actions/upload-artifact@v3
@@ -27,22 +32,11 @@ jobs:
           if-no-files-found: error
           path: .next
 
-  install-cypress:
-    name: Install Cypress
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      # pass runTests: false to the Cypress GitHub Action to instruct it only to install and cache Cypress and npm dependencies without running the tests
-      # https://docs.cypress.io/guides/continuous-integration/github-actions#Parallelization
-      - uses: cypress-io/github-action@v4
-        with:
-          runTests: false
-
   tests:
     name: Run Cypress Tests
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    needs: [build, install-cypress]
+    needs: build
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -6,26 +6,12 @@ on:
       - main
   pull_request:
 
-env:
-  percy-comment-title: Percy Snapshot Comparison
-  percy-comment-id: percy-status
-
 jobs:
   build:
     name: Build UI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Comment Percy status on PR
-        uses: skylark-platform/comment-url-on-pr@v1
-        with:
-          title: ${{ env.percy-comment-title }}
-          comment_id: ${{ env.percy-comment-id }}
-          status: building
-          github_token: ${{ github.token }}
-      - uses: cypress-io/github-action@v4
-        with:
-          runTests: false
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - run: vercel env pull --yes --environment=development --token=${{ secrets.VERCEL_TOKEN }} .env
@@ -40,15 +26,26 @@ jobs:
           if-no-files-found: error
           path: .next
 
+  install-cypress:
+    name: Install Cypress
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # pass runTests: false to the Cypress GitHub Action to instruct it only to install and cache Cypress and npm dependencies without running the tests
+      # https://docs.cypress.io/guides/continuous-integration/github-actions#Parallelization
+      - uses: cypress-io/github-action@v4
+        with:
+          runTests: false
+
   tests:
     name: Run Cypress Tests
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, install-cypress]
     strategy:
       fail-fast: false
       matrix:
-        containers: [1, 2, 3, 4]
+        containers: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v3
       - name: Download the build folders
@@ -64,7 +61,7 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       - name: Load environment variables from .env
         uses: xom9ikk/dotenv@v2
-      - name: UI Tests
+      - name: Cypress tests
         uses: cypress-io/github-action@v4
         with:
           start: yarn start
@@ -80,7 +77,7 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-          PERCY_PARALLEL_TOTAL: 4
+          PERCY_PARALLEL_TOTAL: 5
           # overwrite commit message sent to Dashboard
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
           # re-enable PR comment bot

--- a/cypress/e2e/contentLibrary/dragdrop.cy.ts
+++ b/cypress/e2e/contentLibrary/dragdrop.cy.ts
@@ -327,11 +327,9 @@ describe("Drag and Drop - Content and Relationship tab", () => {
               .trigger("mouseup", { force: true })
               .wait(250)
               .then(() => {
-                cy.get("[data-testid=toast]")
-                  .first()
-                  .within(() => {
-                    cy.contains("Existing Linked Object").should("exist");
-                  });
+                cy.get("[data-testid=toast]").within(() => {
+                  cy.contains("Existing Linked Object").should("exist");
+                });
               });
           },
         );

--- a/cypress/e2e/contentLibrary/search.cy.ts
+++ b/cypress/e2e/contentLibrary/search.cy.ts
@@ -19,7 +19,7 @@ describe("Content Library - Search", () => {
         });
       }
       if (hasOperationName(req, "GET_OBJECTS_CONFIG")) {
-        req.alias = "introspectionQuery";
+        req.alias = "getObjectConfig";
         req.reply({
           fixture: "./skylark/queries/getObjectsConfig/allObjectsConfig.json",
         });
@@ -105,6 +105,7 @@ describe("Content Library - Search", () => {
 
     cy.visit("/");
     cy.wait("@introspectionQuery");
+    cy.wait("@getObjectConfig");
   });
 
   it("visits home", () => {

--- a/cypress/e2e/contentLibrary/search.cy.ts
+++ b/cypress/e2e/contentLibrary/search.cy.ts
@@ -112,6 +112,8 @@ describe("Content Library - Search", () => {
       "not.exist",
     );
     cy.contains("GOT");
+    cy.contains("All object types translated to en-GB");
+
     cy.percySnapshot("Homepage");
   });
 
@@ -129,6 +131,9 @@ describe("Content Library - Search", () => {
 
     cy.wait("@searchQueryEmpty");
     cy.contains("We couldn't find matches for the search term.");
+
+    cy.contains("All object types translated to en-GB");
+
     cy.percySnapshot("Homepage - no search data");
   });
 
@@ -273,6 +278,9 @@ describe("Content Library - Search", () => {
     );
 
     cy.contains("Classic kids shows");
+
+    // Wait for second page of search results to load before Percy screenshot
+    cy.get(`[data-cy=pill]`).should("exist").should("have.length.at.least", 15);
 
     cy.percySnapshot("Homepage - Filtered By Availability Dimensions (kids)");
   });

--- a/cypress/e2e/contentLibrary/search.cy.ts
+++ b/cypress/e2e/contentLibrary/search.cy.ts
@@ -112,7 +112,7 @@ describe("Content Library - Search", () => {
       "not.exist",
     );
     cy.contains("GOT");
-    cy.contains("All object types translated to en-GB");
+    cy.contains("All object types translated to en-GB", { timeout: 10000 });
 
     cy.percySnapshot("Homepage");
   });
@@ -132,7 +132,7 @@ describe("Content Library - Search", () => {
     cy.wait("@searchQueryEmpty");
     cy.contains("We couldn't find matches for the search term.");
 
-    cy.contains("All object types translated to en-GB");
+    cy.contains("All object types translated to en-GB", { timeout: 10000 });
 
     cy.percySnapshot("Homepage - no search data");
   });

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
-  "rangeStrategy": "pin"
+  "rangeStrategy": "pin",
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch"
+    }
+  ],
+  "schedule": ["before 4am on Monday"]
 }

--- a/src/components/availability/summary/availabilitySummary.component.tsx
+++ b/src/components/availability/summary/availabilitySummary.component.tsx
@@ -3,6 +3,7 @@ import clsx from "clsx";
 import { useAvailabilityDimensionsWithValues } from "src/hooks/availability/useAvailabilityDimensionWithValues";
 import { SearchType } from "src/hooks/useSearchWithLookupType";
 import { useSkylarkObjectTypesWithConfig } from "src/hooks/useSkylarkObjectTypes";
+import { ParsedSkylarkObjectConfig } from "src/interfaces/skylark";
 import { formatReadableDateTime } from "src/lib/skylark/availability";
 
 const prettifyStrArr = (arr: string[]): string => {
@@ -15,6 +16,40 @@ const prettifyStrArr = (arr: string[]): string => {
   }
 
   return `${arr.slice(0, arr.length - 1).join(", ")} & ${arr[arr.length - 1]}`;
+};
+
+const buildObjectTypesStr = (
+  filteredObjectTypes: string[] | null,
+  numObjectTypes?: number,
+  allObjectTypesWithConfig?: {
+    objectType: string;
+    config: ParsedSkylarkObjectConfig;
+  }[],
+) => {
+  if (!filteredObjectTypes) {
+    return <>Objects </>;
+  }
+
+  if (filteredObjectTypes.length === numObjectTypes) {
+    return <>All object types </>;
+  }
+
+  const parsedObjectTypes = filteredObjectTypes.map((objectType) => {
+    const objectTypeWithConfig = allObjectTypesWithConfig?.find(
+      ({ objectType: name }) => name === objectType,
+    );
+    return objectTypeWithConfig?.config.objectTypeDisplayName || objectType;
+  });
+
+  if (filteredObjectTypes.length < 10) {
+    return (
+      <>
+        <strong>{prettifyStrArr(parsedObjectTypes)}</strong> objects{" "}
+      </>
+    );
+  }
+
+  return <>{filteredObjectTypes.length} object types </>;
 };
 
 // `"Episode" filtered by "search query"`
@@ -39,37 +74,17 @@ export const AvailabilitySummary = ({
     timeTravel: { datetime: string; timezone: string } | null;
   };
 }) => {
-  const { objectTypesWithConfig } = useSkylarkObjectTypesWithConfig();
+  const { objectTypesWithConfig, numObjectTypes } =
+    useSkylarkObjectTypesWithConfig();
 
   const { dimensions: allDimensionsWithValues } =
     useAvailabilityDimensionsWithValues();
 
-  let objectTypeStr = <>Objects </>;
-
-  if (objectTypes) {
-    const parsedObjectTypes = objectTypes.map((objectType) => {
-      const objectTypeWithConfig = objectTypesWithConfig?.find(
-        ({ objectType: name }) => name === objectType,
-      );
-      return objectTypeWithConfig?.config.objectTypeDisplayName || objectType;
-    });
-
-    objectTypeStr =
-      objectTypes.length < 10 ? (
-        <>
-          <strong>{prettifyStrArr(parsedObjectTypes)}</strong> objects{" "}
-        </>
-      ) : (
-        <>
-          <strong>
-            {objectTypesWithConfig?.length === objectTypes.length
-              ? "All"
-              : objectTypes.length}
-          </strong>{" "}
-          object types{" "}
-        </>
-      );
-  }
+  const objectTypeStr = buildObjectTypesStr(
+    objectTypes,
+    numObjectTypes,
+    objectTypesWithConfig,
+  );
 
   const translationStr = language ? (
     <>

--- a/src/components/availability/summary/availabilitySummary.component.tsx
+++ b/src/components/availability/summary/availabilitySummary.component.tsx
@@ -26,12 +26,16 @@ const buildObjectTypesStr = (
     config: ParsedSkylarkObjectConfig;
   }[],
 ) => {
-  if (!filteredObjectTypes) {
-    return <>Objects </>;
-  }
-
-  if (filteredObjectTypes.length === numObjectTypes) {
-    return <>All object types </>;
+  // If object types are null, search will fetch all
+  if (
+    filteredObjectTypes === null ||
+    filteredObjectTypes.length === numObjectTypes
+  ) {
+    return (
+      <>
+        <strong>All</strong> object types{" "}
+      </>
+    );
   }
 
   const parsedObjectTypes = filteredObjectTypes.map((objectType) => {
@@ -49,7 +53,11 @@ const buildObjectTypesStr = (
     );
   }
 
-  return <>{filteredObjectTypes.length} object types </>;
+  return (
+    <>
+      <strong>{filteredObjectTypes.length}</strong> object types{" "}
+    </>
+  );
 };
 
 // `"Episode" filtered by "search query"`

--- a/src/components/availability/summary/availabilitySummary.test.tsx
+++ b/src/components/availability/summary/availabilitySummary.test.tsx
@@ -33,7 +33,15 @@ test("shows a default string when minimal props are given", () => {
     <AvailabilitySummary {...defaultProps} />,
   );
 
-  expect(container).toHaveTextContent("Objects");
+  expect(container).toHaveTextContent("All object types");
+});
+
+test("shows all object types when objectTypes are null (haven't been fetched yet)", () => {
+  const { container } = renderWithMinimalProviders(
+    <AvailabilitySummary {...defaultProps} objectTypes={null} />,
+  );
+
+  expect(container).toHaveTextContent("All object types");
 });
 
 test("shows object types when under 10 are given", () => {
@@ -76,7 +84,7 @@ test("shows query string", () => {
   );
 
   expect(container).toHaveTextContent(
-    "Objects filtered by query “My search query”",
+    "All object types filtered by query “My search query”",
   );
 });
 
@@ -90,7 +98,7 @@ test("shows UID string when searchType is UID/ExternalID", () => {
   );
 
   expect(container).toHaveTextContent(
-    "Objects filtered by UID or External ID “MYTESTUID”",
+    "All object types filtered by UID or External ID “MYTESTUID”",
   );
 });
 
@@ -99,7 +107,7 @@ test("shows language", () => {
     <AvailabilitySummary {...defaultProps} language={"en-GB"} />,
   );
 
-  expect(container).toHaveTextContent("Objects translated to en-GB");
+  expect(container).toHaveTextContent("All object types translated to en-GB");
 });
 
 test("shows Availability dimensions", () => {
@@ -114,7 +122,7 @@ test("shows Availability dimensions", () => {
   );
 
   expect(container).toHaveTextContent(
-    "Objects available to premium & pc users",
+    "All object types available to premium & pc users",
   );
 });
 
@@ -133,7 +141,9 @@ test("shows Availability time travel", () => {
   );
 
   expect(container).toHaveTextContent(
-    `Objects available on ${formatReadableDateTime("2022-10-30T10:30")}`,
+    `All object types available on ${formatReadableDateTime(
+      "2022-10-30T10:30",
+    )}`,
   );
 });
 
@@ -152,7 +162,7 @@ test("shows Availability dimensions and time travel", () => {
   );
 
   expect(container).toHaveTextContent(
-    `Objects available to premium & pc users on ${formatReadableDateTime(
+    `All object types available to premium & pc users on ${formatReadableDateTime(
       "2022-10-30T10:30",
     )}`,
   );

--- a/src/components/panel/panelSections/panelAvailability.component.tsx
+++ b/src/components/panel/panelSections/panelAvailability.component.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import dayjs from "dayjs";
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 
 import { AvailabilityLabel } from "src/components/availability";
 import { OpenObjectButton } from "src/components/button";
@@ -213,9 +213,9 @@ export const PanelAvailability = (props: PanelAvailabilityProps) => {
 
   const now = dayjs();
 
-  const availabilityObjects = mergeServerAndModifiedAvailability(
-    data,
-    modifiedAvailabilityObjects,
+  const availabilityObjects = useMemo(
+    () => mergeServerAndModifiedAvailability(data, modifiedAvailabilityObjects),
+    [data, modifiedAvailabilityObjects],
   );
 
   const removeAvailabilityObject = (uidToRemove: string) => {

--- a/src/components/panel/panelSections/panelRelationships.component.tsx
+++ b/src/components/panel/panelSections/panelRelationships.component.tsx
@@ -211,22 +211,6 @@ export const PanelRelationships = ({
     [inEditMode, modifiedRelationships, serverRelationships],
   );
 
-  useEffect(
-    () => console.log("modifiedRelationships"),
-    [modifiedRelationships],
-  );
-  useEffect(() => console.log("droppedObjects"), [droppedObjects]);
-  useEffect(
-    () => console.log("objectMetaRelationships"),
-    [objectMetaRelationships],
-  );
-  useEffect(() => console.log("relationships"), [relationships]);
-  useEffect(
-    () => console.log("setModifiedRelationships"),
-    [setModifiedRelationships],
-  );
-  useEffect(() => console.log("uid"), [uid]);
-
   useEffect(() => {
     if (
       droppedObjects &&
@@ -234,7 +218,6 @@ export const PanelRelationships = ({
       objectMetaRelationships &&
       relationships
     ) {
-      console.log("*** HANDLE");
       const { addedObjects, errors } = handleDroppedRelationships({
         droppedObjects,
         activeObjectUid: uid,

--- a/src/components/panel/panelSections/panelRelationships.component.tsx
+++ b/src/components/panel/panelSections/panelRelationships.component.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { sentenceCase } from "sentence-case";
 
 import { DisplayGraphQLQuery, SearchObjectsModal } from "src/components/modals";
@@ -200,12 +200,32 @@ export const PanelRelationships = ({
     variables,
   } = useGetObjectRelationships(objectType, uid, { language });
 
-  const relationships = inEditMode
-    ? addModifiedRelationshipsOntoRelationships(
-        serverRelationships,
-        modifiedRelationships,
-      )
-    : serverRelationships;
+  const relationships = useMemo(
+    () =>
+      inEditMode
+        ? addModifiedRelationshipsOntoRelationships(
+            serverRelationships,
+            modifiedRelationships,
+          )
+        : serverRelationships,
+    [inEditMode, modifiedRelationships, serverRelationships],
+  );
+
+  useEffect(
+    () => console.log("modifiedRelationships"),
+    [modifiedRelationships],
+  );
+  useEffect(() => console.log("droppedObjects"), [droppedObjects]);
+  useEffect(
+    () => console.log("objectMetaRelationships"),
+    [objectMetaRelationships],
+  );
+  useEffect(() => console.log("relationships"), [relationships]);
+  useEffect(
+    () => console.log("setModifiedRelationships"),
+    [setModifiedRelationships],
+  );
+  useEffect(() => console.log("uid"), [uid]);
 
   useEffect(() => {
     if (
@@ -214,6 +234,7 @@ export const PanelRelationships = ({
       objectMetaRelationships &&
       relationships
     ) {
+      console.log("*** HANDLE");
       const { addedObjects, errors } = handleDroppedRelationships({
         droppedObjects,
         activeObjectUid: uid,

--- a/src/components/pill/pill.component.tsx
+++ b/src/components/pill/pill.component.tsx
@@ -22,6 +22,7 @@ export const Pill = ({ label, bgColor, className, onDelete }: PillProps) => (
         "bg-manatee-300",
     )}
     style={bgColor ? { backgroundColor: bgColor } : undefined}
+    data-cy="pill"
   >
     <span className="overflow-hidden text-clip">{label}</span>
     {onDelete && (

--- a/src/hooks/useSkylarkObjectTypes.ts
+++ b/src/hooks/useSkylarkObjectTypes.ts
@@ -47,7 +47,7 @@ const useObjectTypesConfig = (objectTypes?: string[]) => {
   const { data } = useQuery<GQLSkylarkObjectTypesWithConfig>({
     queryKey: [QueryKeys.ObjectTypesConfig, query],
     queryFn: async () => skylarkRequest("query", query as DocumentNode),
-    enabled: query !== null,
+    enabled: objectTypes && query !== null,
     refetchOnWindowFocus: false,
     refetchOnMount: false,
     staleTime: 5 * 60 * 1000, // 5 minutes
@@ -75,6 +75,7 @@ const useObjectTypesConfig = (objectTypes?: string[]) => {
 
   return {
     objectTypesWithConfig,
+    numObjectTypes: objectTypes?.length,
   };
 };
 


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->

- Tweak Cypress tests to improve their reliability and make Percy snapshots change less
- Increase Cypress parallel to 5
- Make Renovate bundle non-major changes into a single PR, only run on Monday
-  
<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Bugfix

#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://skylarkplatform.atlassian.net/browse/< ticket_id >

