### PR TITLE
feat: Bulk Delete & Improved Tab State History

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,8 @@
     "className",
     ".*ClassName*",
     ".*ClassNames*"
+  ],
+  "tailwindCSS.experimental.classRegex": [
+    ["clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
   ]
 }

--- a/src/__tests__/fixtures/skylark/mutations/batchDeleteObjects.json
+++ b/src/__tests__/fixtures/skylark/mutations/batchDeleteObjects.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "batchDeleteObjects": {
+      "language": null,
+      "removed_relationships": null,
+      "message": null,
+      "task_id": "44a2d633-3643-4232-b172-002a8cc1f06b"
+    }
+  }
+}

--- a/src/__tests__/fixtures/skylark/queries/getAccountStatus/deletionBackgroundTasksInProgress.json
+++ b/src/__tests__/fixtures/skylark/queries/getAccountStatus/deletionBackgroundTasksInProgress.json
@@ -1,0 +1,49 @@
+{
+  "data": {
+    "getActivationStatus": {
+      "active_version": "2",
+      "update_in_progress": false,
+      "update_started_at": null
+    },
+    "queuedBackgroundTasks": {
+      "next_token": null,
+      "objects": [
+        {
+          "created_at": "2023-11-06T12:36:24.663184+00:00",
+          "messages": [],
+          "object_uid": "BATCH_DELETE",
+          "status": "QUEUED",
+          "task_type": "batch_delete",
+          "task_id": "fa9bd32c-6642-4dc4-bc18-b72d94f01a9f",
+          "updated_at": "2023-11-06T12:36:24.663184+00:00"
+        },
+        {
+          "created_at": "2023-11-06T12:36:56.634055+00:00",
+          "messages": [],
+          "object_uid": "01HEJ67P1NKXEY97XGG1RAQ81H",
+          "status": "QUEUED",
+          "task_type": "delete_post_processing",
+          "task_id": "9fbe1c04-16b9-4ed7-864c-282e93055c8a",
+          "updated_at": "2023-11-06T12:36:56.634055+00:00"
+        },
+        {
+          "created_at": "2023-11-06T12:36:56.471249+00:00",
+          "messages": [],
+          "object_uid": "01HEJ67P30EPBYDQ0BEMBDY461",
+          "status": "QUEUED",
+          "task_type": "delete_post_processing",
+          "task_id": "cac594d0-f3de-4b60-aadd-182d3c34987f",
+          "updated_at": "2023-11-06T12:36:56.471249+00:00"
+        }
+      ]
+    },
+    "inProgressBackgroundTasks": {
+      "next_token": null,
+      "objects": []
+    },
+    "failedBackgroundTasks": {
+      "next_token": null,
+      "objects": []
+    }
+  }
+}

--- a/src/__tests__/mocks/handlers/deleteObjectHandlers.ts
+++ b/src/__tests__/mocks/handlers/deleteObjectHandlers.ts
@@ -1,5 +1,6 @@
 import { graphql } from "msw";
 
+import GQLSkylarkBatchDeleteObjectsFixture from "src/__tests__/fixtures/skylark/mutations/batchDeleteObjects.json";
 import GQLSkylarkGetObjectGOTS01E01QueryFixture from "src/__tests__/fixtures/skylark/queries/getObject/gots01e01.json";
 
 export const deleteObjectHandlers = [
@@ -11,5 +12,9 @@ export const deleteObjectHandlers = [
         },
       }),
     );
+  }),
+
+  graphql.mutation(`BATCH_DELETE`, (req, res, ctx) => {
+    return res(ctx.data(GQLSkylarkBatchDeleteObjectsFixture));
   }),
 ];

--- a/src/components/account/status/accountStatus.component.tsx
+++ b/src/components/account/status/accountStatus.component.tsx
@@ -11,17 +11,22 @@ import {
   GQLSkylarkBackgroundTask,
 } from "src/interfaces/skylark";
 
-type GenericTaskType = "availability" | "other";
+type GenericTaskType = "availability" | "deletion" | "other";
 
 const stringifyCount = (count: number) => (count >= 50 ? "50+" : `${count}`);
 
-const getGenericBackgroundTaskType = (task: GQLSkylarkBackgroundTask) => {
+const getGenericBackgroundTaskType = (
+  task: GQLSkylarkBackgroundTask,
+): GenericTaskType => {
   switch (task.task_type) {
     case BackgroundTaskType.AVAILABILITY_UPDATE_OBJECT_PROCESSING:
     case BackgroundTaskType.AVAILABILITY_DELETE_OBJECT_PROCESSING:
     case BackgroundTaskType.POST_AVAILABILITY_UPDATE:
     case BackgroundTaskType.POST_AVAILABILITY_DELETE:
       return "availability";
+    case BackgroundTaskType.BATCH_DELETE:
+    case BackgroundTaskType.DELETE_POST_PROCESSING:
+      return "deletion";
     case BackgroundTaskType.POST_CREATE:
     case BackgroundTaskType.POST_UPDATE:
     default:
@@ -43,6 +48,10 @@ const getBackgroundTaskTypeText = (tasks: GQLSkylarkBackgroundTask[]) => {
 
     if (type === "availability") {
       return `${count} Availability Rules`;
+    }
+
+    if (type === "deletion") {
+      return `${count} Deletion Requests`;
     }
   }
 

--- a/src/components/account/status/accountStatus.test.tsx
+++ b/src/components/account/status/accountStatus.test.tsx
@@ -4,6 +4,7 @@ import { graphql } from "msw";
 import GQLSkylarkAccountStatusAvailabilityBackgroundTasksFixture from "src/__tests__/fixtures/skylark/queries/getAccountStatus/availabilityBackgroundTasksInProgress.json";
 import GQLSkylarkAccountStatusBackgroundTasksFixture from "src/__tests__/fixtures/skylark/queries/getAccountStatus/backgroundTasksInProgress.json";
 import GQLSkylarkAccountStatusDefault from "src/__tests__/fixtures/skylark/queries/getAccountStatus/default.json";
+import GQLSkylarkAccountStatusDeletionBackgroundTasksFixture from "src/__tests__/fixtures/skylark/queries/getAccountStatus/deletionBackgroundTasksInProgress.json";
 import GQLSkylarkAccountStatusSchemaUpdate from "src/__tests__/fixtures/skylark/queries/getAccountStatus/schemaUpdateInProgress.json";
 import { server } from "src/__tests__/mocks/server";
 import { render, screen, waitFor } from "src/__tests__/utils/test-utils";
@@ -31,6 +32,24 @@ test("renders showing Availability processing", async () => {
   });
 });
 
+test("renders showing Delete processing", async () => {
+  server.use(
+    graphql.query(GET_ACCOUNT_STATUS, (req, res, ctx) => {
+      return res(
+        ctx.data(GQLSkylarkAccountStatusDeletionBackgroundTasksFixture.data),
+      );
+    }),
+  );
+
+  render(<AccountStatus />);
+
+  await waitFor(() => {
+    expect(
+      screen.getByText("Processing 3 Deletion Requests"),
+    ).toBeInTheDocument();
+  });
+});
+
 test("renders showing Background tasks processing when more than one task_type exist", async () => {
   server.use(
     graphql.query(GET_ACCOUNT_STATUS, (req, res, ctx) => {
@@ -42,7 +61,7 @@ test("renders showing Background tasks processing when more than one task_type e
 
   await waitFor(() => {
     expect(
-      screen.getByText("Processing 38 Background Tasks"),
+      screen.getByText("Processing 20 Background Tasks"),
     ).toBeInTheDocument();
   });
 });

--- a/src/components/contentLibrary/contentLibrary.component.tsx
+++ b/src/components/contentLibrary/contentLibrary.component.tsx
@@ -81,11 +81,13 @@ export const ContentLibrary = ({
   const {
     activePanelObject,
     activePanelTab,
+    activePanelTabState,
     setPanelObject,
     setPanelTab,
     navigateToPreviousPanelObject,
     navigateToForwardPanelObject,
     resetPanelObjectState,
+    updateActivePanelTabState,
   } = usePanelObjectState();
 
   const {
@@ -292,6 +294,7 @@ export const ContentLibrary = ({
                 key={`${activePanelObject.objectType}-${activePanelObject.uid}-${activePanelObject.language}`}
                 object={activePanelObject}
                 tab={activePanelTab}
+                tabState={activePanelTabState}
                 closePanel={closePanel}
                 isDraggedObject={isDraggingObject}
                 droppedObjects={droppedObjects}
@@ -300,6 +303,7 @@ export const ContentLibrary = ({
                 navigateToPreviousPanelObject={navigateToPreviousPanelObject}
                 navigateToForwardPanelObject={navigateToForwardPanelObject}
                 clearDroppedObjects={clearDroppedObjects}
+                updateActivePanelTabState={updateActivePanelTabState}
               />
             </div>
           </m.div>

--- a/src/components/inputs/textInput/textInput.component.tsx
+++ b/src/components/inputs/textInput/textInput.component.tsx
@@ -1,8 +1,13 @@
 import clsx from "clsx";
+import { DetailedHTMLProps, InputHTMLAttributes } from "react";
 
 import { CopyToClipboard } from "src/components/copyToClipboard/copyToClipboard.component";
 
-interface TextInputProps {
+interface TextInputProps
+  extends Omit<
+    DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>,
+    "onChange"
+  > {
   value: string;
   onChange: (str: string) => void;
   className?: string;

--- a/src/components/modals/batchDeleteObjectsModal/batchDeleteObjectsModal.component.tsx
+++ b/src/components/modals/batchDeleteObjectsModal/batchDeleteObjectsModal.component.tsx
@@ -4,6 +4,7 @@ import { toast } from "react-toastify";
 import { useDebouncedCallback } from "use-debounce";
 
 import { Button } from "src/components/button";
+import { TextInput } from "src/components/inputs/textInput";
 import { Modal } from "src/components/modals/base/modal";
 import { ObjectIdentifierCard } from "src/components/objectIdentifierCard";
 import { Toast } from "src/components/toast/toast.component";
@@ -12,6 +13,7 @@ import { ParsedSkylarkObject } from "src/interfaces/skylark";
 import { hasProperty } from "src/lib/utils";
 
 const DELETION_LIMIT = 100;
+const VERIFICATION_TEXT = "permanently delete";
 
 interface BatchDeleteObjectsModalProps {
   objectsToBeDeleted: ParsedSkylarkObject[];
@@ -55,52 +57,66 @@ const DeleteButtonWithConfirmation = ({
   isDeleting: boolean;
 }) => {
   const [showDeleteVerification, setShowDeleteVerficiation] = useState(false);
-  const [deleteButtonDisabled, setDeleteButtonDisabled] = useState(true);
+  const [input, setInput] = useState("");
 
   return (
-    <div className="mt-6 flex justify-end space-x-2">
-      {showDeleteVerification ? (
-        <>
-          <Button
-            variant="primary"
-            type="button"
-            danger
-            loading={isDeleting}
-            disabled={deleteButtonDisabled}
-            onClick={() => {
-              onConfirmed();
-            }}
-          >
-            {confirmationMessage}
-          </Button>
-          <Button
-            variant="outline"
-            type="button"
-            onClick={() => setShowDeleteVerficiation(false)}
-          >
-            Go back
-          </Button>
-        </>
-      ) : (
-        <>
-          <Button
-            variant="primary"
-            type="button"
-            danger
-            loading={false}
-            onClick={() => {
-              setDeleteButtonDisabled(true);
-              setTimeout(() => setDeleteButtonDisabled(false), 2000);
-              setShowDeleteVerficiation(true);
-            }}
-          >
-            {`Delete objects`}
-          </Button>
-          <Button variant="outline" type="button" onClick={onCancel}>
-            Cancel
-          </Button>
-        </>
+    <div className="mt-6">
+      {showDeleteVerification && (
+        <div>
+          <p className="mb-2">
+            {`To confirm deletion, enter "${VERIFICATION_TEXT}" in the text input
+            field.`}
+          </p>
+          <TextInput
+            value={input}
+            onChange={setInput}
+            placeholder={VERIFICATION_TEXT}
+          />
+        </div>
       )}
+      <div className="mt-4 flex justify-end space-x-2">
+        {showDeleteVerification ? (
+          <>
+            <Button
+              variant="primary"
+              type="button"
+              danger
+              loading={isDeleting}
+              disabled={input !== VERIFICATION_TEXT}
+              onClick={() => {
+                onConfirmed();
+              }}
+            >
+              {confirmationMessage}
+            </Button>
+            <Button
+              variant="outline"
+              type="button"
+              onClick={() => setShowDeleteVerficiation(false)}
+            >
+              Go back
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button
+              variant="primary"
+              type="button"
+              danger
+              loading={false}
+              onClick={() => {
+                setInput("");
+                setShowDeleteVerficiation(true);
+              }}
+            >
+              {`Delete objects`}
+            </Button>
+            <Button variant="outline" type="button" onClick={onCancel}>
+              Cancel
+            </Button>
+          </>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/modals/batchDeleteObjectsModal/batchDeleteObjectsModal.component.tsx
+++ b/src/components/modals/batchDeleteObjectsModal/batchDeleteObjectsModal.component.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { useCallback, useRef, useState } from "react";
+import { Fragment, useCallback, useRef, useState } from "react";
 import { toast } from "react-toastify";
 import { useDebouncedCallback } from "use-debounce";
 
@@ -207,6 +207,10 @@ const BatchDeleteObjectsModalContent = ({
         ref={containerRef}
         onScroll={debouncedOnScroll}
       >
+        {objects.length === 0 && propObjects.length !== 0 && (
+          <p>No objects selected for deletion.</p>
+        )}
+
         {Object.entries(groupedObjectsByUID).map(([uid, objects]) => {
           return (
             <div
@@ -220,7 +224,7 @@ const BatchDeleteObjectsModalContent = ({
               {objects.map((obj) => {
                 const index = orderedObjects.findIndex((_obj) => obj === _obj);
                 return (
-                  <>
+                  <Fragment key={obj.meta.language}>
                     {obj === firstObjectOverTheLimit && (
                       <div className="mt-8 border-t-2 border-error pb-6 pt-8">
                         <p className="font-medium">
@@ -244,7 +248,7 @@ const BatchDeleteObjectsModalContent = ({
                         <p className="pr-1 text-manatee-500">{`${obj.meta.language}`}</p>
                       </ObjectIdentifierCard>
                     </div>
-                  </>
+                  </Fragment>
                 );
               })}
             </div>

--- a/src/components/modals/batchDeleteObjectsModal/batchDeleteObjectsModal.stories.tsx
+++ b/src/components/modals/batchDeleteObjectsModal/batchDeleteObjectsModal.stories.tsx
@@ -1,4 +1,5 @@
 import { ComponentStory, Story } from "@storybook/react";
+import { userEvent, waitFor, within } from "@storybook/testing-library";
 
 import {
   AvailabilityStatus,
@@ -57,4 +58,26 @@ Default.args = {
       metadata: { uid: "246", external_id: "", title: "My Movie" },
     },
   ],
+};
+
+export const Confirmation = Template.bind({});
+Confirmation.args = {
+  isOpen: true,
+  closeModal: () => "",
+  objectsToBeDeleted: [
+    object,
+    {
+      ...object,
+      objectType: "Movie",
+      uid: "246",
+      metadata: { uid: "246", external_id: "", title: "My Movie" },
+    },
+  ],
+};
+Confirmation.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+
+  await userEvent.click(canvas.getByText("Delete objects"));
+
+  await canvas.findByPlaceholderText(/permanently delete/);
 };

--- a/src/components/modals/batchDeleteObjectsModal/batchDeleteObjectsModal.stories.tsx
+++ b/src/components/modals/batchDeleteObjectsModal/batchDeleteObjectsModal.stories.tsx
@@ -1,0 +1,60 @@
+import { ComponentStory, Story } from "@storybook/react";
+
+import {
+  AvailabilityStatus,
+  ParsedSkylarkObject,
+} from "src/interfaces/skylark";
+
+import { BatchDeleteObjectsModal } from "./batchDeleteObjectsModal.component";
+
+const object: ParsedSkylarkObject = {
+  uid: "123",
+  objectType: "Episode",
+  meta: {
+    language: "en-GB",
+    availableLanguages: ["en-GB"],
+    availabilityStatus: AvailabilityStatus.Active,
+  },
+  metadata: {
+    uid: "123",
+    external_id: "",
+    title: "My Episode",
+  },
+  config: { primaryField: "title" },
+  availability: {
+    status: AvailabilityStatus.Active,
+    objects: [],
+  },
+};
+
+export default {
+  title: "Components/Modals/BatchDeleteObjectsModal",
+  component: BatchDeleteObjectsModal,
+  // Decorator to increase Story height https://www.chromatic.com/docs/snapshots#why-are-components-that-render-in-a-portal-tooltip-modal-menu-ge
+  decorators: [
+    (StoryComponent: Story) => (
+      <div className="h-screen w-screen">
+        <StoryComponent />
+      </div>
+    ),
+  ],
+};
+
+const Template: ComponentStory<typeof BatchDeleteObjectsModal> = (args) => {
+  return <BatchDeleteObjectsModal {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  isOpen: true,
+  closeModal: () => "",
+  objectsToBeDeleted: [
+    object,
+    {
+      ...object,
+      objectType: "Movie",
+      uid: "246",
+      metadata: { uid: "246", external_id: "", title: "My Movie" },
+    },
+  ],
+};

--- a/src/components/modals/batchDeleteObjectsModal/batchDeleteObjectsModal.stories.tsx
+++ b/src/components/modals/batchDeleteObjectsModal/batchDeleteObjectsModal.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, Story } from "@storybook/react";
-import { userEvent, waitFor, within } from "@storybook/testing-library";
+import { userEvent, within } from "@storybook/testing-library";
 
 import {
   AvailabilityStatus,
@@ -74,10 +74,12 @@ Confirmation.args = {
     },
   ],
 };
-Confirmation.play = async ({ canvasElement }) => {
-  const canvas = within(canvasElement);
+Confirmation.play = async () => {
+  const headlessPortalRoot = document.querySelector("#headlessui-portal-root");
+  const headlessCanvas = within(headlessPortalRoot as HTMLElement);
 
-  await userEvent.click(canvas.getByText("Delete objects"));
+  const buttom = await headlessCanvas.findByText("Delete objects");
+  await userEvent.click(buttom);
 
-  await canvas.findByPlaceholderText(/permanently delete/);
+  await headlessCanvas.findByPlaceholderText(/permanently delete/);
 };

--- a/src/components/modals/batchDeleteObjectsModal/batchDeleteObjectsModal.test.tsx
+++ b/src/components/modals/batchDeleteObjectsModal/batchDeleteObjectsModal.test.tsx
@@ -1,0 +1,298 @@
+import { waitFor, screen, within, fireEvent } from "@testing-library/react";
+import { graphql } from "msw";
+
+import { server } from "src/__tests__/mocks/server";
+import { render } from "src/__tests__/utils/test-utils";
+import {
+  AvailabilityStatus,
+  ParsedSkylarkObject,
+} from "src/interfaces/skylark";
+
+import { BatchDeleteObjectsModal } from "./batchDeleteObjectsModal.component";
+
+const object: ParsedSkylarkObject = {
+  objectType: "Episode",
+  uid: "123",
+  meta: {
+    language: "en-GB",
+    availableLanguages: ["en-GB"],
+    availabilityStatus: AvailabilityStatus.Unavailable,
+  },
+  metadata: { uid: "123", external_id: "" },
+  config: { primaryField: "title" },
+  availability: {
+    objects: [],
+    status: AvailabilityStatus.Unavailable,
+  },
+};
+
+test("renders the modal", async () => {
+  render(
+    <BatchDeleteObjectsModal
+      isOpen={true}
+      objectsToBeDeleted={[]}
+      closeModal={jest.fn()}
+      removeObject={jest.fn()}
+      onDeletionComplete={jest.fn()}
+    />,
+  );
+
+  await waitFor(() =>
+    expect(
+      screen.getByTestId("batch-delete-objects-modal"),
+    ).toBeInTheDocument(),
+  );
+  expect(screen.getByText("Bulk Delete")).toBeInTheDocument();
+});
+
+test("calls closeModal when cancel is clicked", async () => {
+  const closeModal = jest.fn();
+
+  render(
+    <BatchDeleteObjectsModal
+      isOpen={true}
+      objectsToBeDeleted={[]}
+      closeModal={closeModal}
+      removeObject={jest.fn()}
+      onDeletionComplete={jest.fn()}
+    />,
+  );
+
+  await waitFor(() =>
+    expect(
+      screen.getByTestId("batch-delete-objects-modal"),
+    ).toBeInTheDocument(),
+  );
+
+  fireEvent.click(screen.getByText("Cancel"));
+  expect(closeModal).toHaveBeenCalled();
+});
+
+test("shows no objects to be deleted when objectsToBeDeleted is empty", async () => {
+  render(
+    <BatchDeleteObjectsModal
+      isOpen={true}
+      objectsToBeDeleted={[]}
+      closeModal={jest.fn()}
+      removeObject={jest.fn()}
+      onDeletionComplete={jest.fn()}
+    />,
+  );
+
+  await waitFor(() =>
+    expect(
+      screen.getByTestId("batch-delete-objects-modal"),
+    ).toBeInTheDocument(),
+  );
+  expect(
+    screen.getByText("No objects selected for deletion."),
+  ).toBeInTheDocument();
+});
+
+test("shows this object will be deleted and the object when all available languages are selected", async () => {
+  render(
+    <BatchDeleteObjectsModal
+      isOpen={true}
+      objectsToBeDeleted={[object]}
+      closeModal={jest.fn()}
+      removeObject={jest.fn()}
+      onDeletionComplete={jest.fn()}
+    />,
+  );
+
+  await waitFor(() =>
+    expect(
+      screen.getByTestId("batch-delete-objects-modal"),
+    ).toBeInTheDocument(),
+  );
+  expect(
+    screen.getByText("The following object will be permanently deleted:"),
+  ).toBeInTheDocument();
+});
+
+test("shows this translation will be deleted and the object when not all available languages are selected", async () => {
+  render(
+    <BatchDeleteObjectsModal
+      isOpen={true}
+      objectsToBeDeleted={[
+        {
+          ...object,
+          meta: { ...object.meta, availableLanguages: ["en-GB", "pt-PT"] },
+        },
+      ]}
+      closeModal={jest.fn()}
+      removeObject={jest.fn()}
+      onDeletionComplete={jest.fn()}
+    />,
+  );
+
+  await waitFor(() =>
+    expect(
+      screen.getByTestId("batch-delete-objects-modal"),
+    ).toBeInTheDocument(),
+  );
+  expect(
+    screen.getByText("The following translation will be permanently deleted:"),
+  ).toBeInTheDocument();
+});
+
+test("shows this translation will be deleted and the object when not all available languages are", async () => {
+  render(
+    <BatchDeleteObjectsModal
+      isOpen={true}
+      objectsToBeDeleted={[
+        object,
+        {
+          ...object,
+          uid: "245",
+          objectType: "Movie",
+          metadata: { uid: "245", external_id: "" },
+        },
+      ]}
+      closeModal={jest.fn()}
+      removeObject={jest.fn()}
+      onDeletionComplete={jest.fn()}
+    />,
+  );
+
+  await waitFor(() =>
+    expect(
+      screen.getByTestId("batch-delete-objects-modal"),
+    ).toBeInTheDocument(),
+  );
+  expect(
+    screen.getByText("The following objects will be permanently deleted:"),
+  ).toBeInTheDocument();
+  expect(screen.getByText(object.objectType)).toBeInTheDocument();
+  expect(screen.getByText("123")).toBeInTheDocument();
+  expect(screen.getByText("245")).toBeInTheDocument();
+});
+
+test("shows some objects will not be deleted when the number of objects exceeds the deletion limit", async () => {
+  const objects: ParsedSkylarkObject[] = Array.from(
+    { length: 150 },
+    (_, i) => ({
+      ...object,
+      uid: `object-${i}`,
+      metadata: {
+        uid: `object-${i}`,
+        external_id: "",
+      },
+    }),
+  );
+  render(
+    <BatchDeleteObjectsModal
+      isOpen={true}
+      objectsToBeDeleted={objects}
+      closeModal={jest.fn()}
+      removeObject={jest.fn()}
+      onDeletionComplete={jest.fn()}
+    />,
+  );
+
+  await waitFor(() =>
+    expect(
+      screen.getByTestId("batch-delete-objects-modal"),
+    ).toBeInTheDocument(),
+  );
+  expect(
+    screen.getByText("The following objects will be permanently deleted:"),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText("These objects will not be deleted:"),
+  ).toBeInTheDocument();
+});
+
+describe("activated delete button", () => {
+  const renderAndActivateDeleteButton = async () => {
+    const closeModal = jest.fn();
+    const onDeletionComplete = jest.fn();
+
+    render(
+      <BatchDeleteObjectsModal
+        isOpen={true}
+        objectsToBeDeleted={[
+          object,
+          {
+            ...object,
+            uid: "245",
+            objectType: "Movie",
+            metadata: { uid: "245", external_id: "" },
+          },
+        ]}
+        closeModal={closeModal}
+        removeObject={jest.fn()}
+        onDeletionComplete={onDeletionComplete}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("batch-delete-objects-modal"),
+      ).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByText("Delete objects"));
+
+    await screen.findByText(
+      'To confirm deletion, enter "permanently delete" in the text input field.',
+    );
+
+    expect(screen.getByText("Permanently delete 2 object(s)")).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText("permanently delete"), {
+      target: { value: "permanently delete" },
+    });
+
+    expect(screen.getByText("Permanently delete 2 object(s)")).toBeEnabled();
+
+    return {
+      closeModal,
+      onDeletionComplete,
+    };
+  };
+
+  test("clicks Delete objects button, switches to confirmation screen, fills in the input, enables the delete button and cancels", async () => {
+    await renderAndActivateDeleteButton();
+
+    fireEvent.click(screen.getByText("Go back"));
+
+    expect(
+      screen.queryByText("Permanently delete 2 object(s)"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("deletes objects and finds a success toast", async () => {
+    await renderAndActivateDeleteButton();
+
+    fireEvent.click(screen.getByText("Permanently delete 2 object(s)"));
+
+    await waitFor(() =>
+      expect(screen.getByText("Batch deletion triggered")).toBeInTheDocument(),
+    );
+  });
+
+  test("errors while deleting objects and finds an error toast", async () => {
+    server.use(
+      graphql.mutation("BATCH_DELETE", (req, res, ctx) => {
+        return res(
+          ctx.errors([
+            {
+              message: "Not authorized",
+            },
+          ]),
+        );
+      }),
+    );
+
+    await renderAndActivateDeleteButton();
+
+    fireEvent.click(screen.getByText("Permanently delete 2 object(s)"));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Batch deletion failed to trigger"),
+      ).toBeInTheDocument(),
+    );
+  });
+});

--- a/src/components/modals/graphQLQueryModal/graphQLQueryModal.stories.tsx
+++ b/src/components/modals/graphQLQueryModal/graphQLQueryModal.stories.tsx
@@ -37,7 +37,10 @@ Default.play = async ({ canvasElement }) => {
 
   await userEvent.click(graphqlButton);
 
+  const headlessPortalRoot = document.querySelector("#headlessui-portal-root");
+  const headlessCanvas = within(headlessPortalRoot as HTMLElement);
+
   await waitFor(async () => {
-    canvas.findAllByText("Query for Schema");
+    headlessCanvas.findAllByText("Query for Schema");
   });
 };

--- a/src/components/objectSearch/bulkObjectOptions/bulkObjectOptions.component.tsx
+++ b/src/components/objectSearch/bulkObjectOptions/bulkObjectOptions.component.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import { FiTrash2, FiMoreVertical } from "react-icons/fi";
+import { toast } from "react-toastify";
 
 import { Button } from "src/components/button";
 import {
@@ -7,6 +8,7 @@ import {
   DropdownMenuButton,
 } from "src/components/dropdown/dropdown.component";
 import { BatchDeleteObjectsModal } from "src/components/modals";
+import { Toast } from "src/components/toast/toast.component";
 import { ParsedSkylarkObject } from "src/interfaces/skylark";
 
 interface BulkObjectOptionsProps {
@@ -18,8 +20,6 @@ export const BulkObjectOptions = ({
   selectedObjects,
   onSelectedObjectChange,
 }: BulkObjectOptionsProps) => {
-  console.log({ selectedObjects });
-
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
 
   const removeObject = useCallback(

--- a/src/components/objectSearch/objectSearch.component.tsx
+++ b/src/components/objectSearch/objectSearch.component.tsx
@@ -26,6 +26,7 @@ import {
   shallowCompareObjects,
 } from "src/lib/utils";
 
+import { BulkObjectOptions } from "./bulkObjectOptions/bulkObjectOptions.component";
 import {
   OBJECT_SEARCH_HARDCODED_COLUMNS,
   OBJECT_SEARCH_ORDERED_KEYS,
@@ -381,8 +382,7 @@ export const ObjectSearch = (props: ObjectSearchProps) => {
       <div
         className={clsx(
           "flex w-full flex-col-reverse items-end space-x-2 md:flex-row md:items-start md:justify-between",
-          isPanelOpen ? "lg:flex-row" : "pr-2 md:flex-row md:pr-8",
-          // "pr-2 md:flex-row md:pr-8", // TODO remove line above and uncomment this line when bulk options is added
+          "pr-2 md:pr-8",
         )}
       >
         <div
@@ -417,10 +417,10 @@ export const ObjectSearch = (props: ObjectSearchProps) => {
             </p>
           </div>
         </div>
-        {/* <BulkObjectOptions
+        <BulkObjectOptions
           selectedObjects={props.checkedObjects || []}
           onSelectedObjectChange={onObjectCheckedChanged}
-        /> */}
+        />
       </div>
       {sortedHeaders.length > 0 && (
         <div

--- a/src/components/panel/__tests__/tabs/relationships.test.tsx
+++ b/src/components/panel/__tests__/tabs/relationships.test.tsx
@@ -97,6 +97,37 @@ describe("relationships view", () => {
     });
   });
 
+  test("calls updateActivePanelTabState with the selected relationship info as true when its expanded", async () => {
+    const updateActivePanelTabState = jest.fn();
+    render(
+      <Panel
+        {...defaultProps}
+        object={seasonWithRelationships}
+        tab={PanelTab.Relationships}
+        updateActivePanelTabState={updateActivePanelTabState}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getAllByText("Episode")).toHaveLength(3));
+
+    const withinEpisodesRelationship = within(screen.getByTestId("episodes"));
+
+    const showMoreButton = withinEpisodesRelationship.getByText("Show more");
+    fireEvent.click(showMoreButton);
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Episode")).toHaveLength(10),
+    );
+
+    expect(updateActivePanelTabState).toHaveBeenCalledWith({
+      Relationships: {
+        expanded: {
+          episodes: true,
+        },
+      },
+    });
+  });
+
   describe("relationships view - edit", () => {
     const renderAndSwitchToEditView = async () => {
       render(

--- a/src/components/panel/__tests__/utils/test-utils.ts
+++ b/src/components/panel/__tests__/utils/test-utils.ts
@@ -14,7 +14,7 @@ import GQLSkylarkGetObjectGOTS01E01PTPTQueryFixture from "src/__tests__/fixtures
 import GQLSkylarkGetSeasonWithRelationshipsQueryFixture from "src/__tests__/fixtures/skylark/queries/getObject/gots04.json";
 import GQLSkylarkGetHomepageSetQueryFixture from "src/__tests__/fixtures/skylark/queries/getObject/homepage.json";
 import { screen, waitFor, within } from "src/__tests__/utils/test-utils";
-import { PanelTab } from "src/hooks/state";
+import { PanelTab, PanelTabState } from "src/hooks/state";
 import {
   BuiltInSkylarkObjectType,
   SkylarkObjectIdentifier,
@@ -71,11 +71,19 @@ export const availabilityObject: SkylarkObjectIdentifier = {
   language: "",
 };
 
+const tabState: PanelTabState = {
+  Relationships: {
+    expanded: {},
+  },
+};
+
 export const defaultProps = {
   closePanel: jest.fn(),
   setPanelObject: jest.fn(),
   setTab: jest.fn(),
+  updateActivePanelTabState: jest.fn(),
   tab: PanelTab.Metadata,
+  tabState,
 };
 
 export const saveGraphQLError: ResponseResolver<

--- a/src/components/panel/panel.component.tsx
+++ b/src/components/panel/panel.component.tsx
@@ -16,7 +16,7 @@ import { useUpdateObjectAvailability } from "src/hooks/objects/update/useUpdateO
 import { useUpdateObjectContent } from "src/hooks/objects/update/useUpdateObjectContent";
 import { useUpdateObjectMetadata } from "src/hooks/objects/update/useUpdateObjectMetadata";
 import { useUpdateObjectRelationships } from "src/hooks/objects/update/useUpdateObjectRelationships";
-import { PanelTab } from "src/hooks/state";
+import { PanelTab, PanelTabState } from "src/hooks/state";
 import {
   ParsedSkylarkObjectContentObject,
   ParsedSkylarkObject,
@@ -59,11 +59,13 @@ interface PanelProps {
   isDraggedObject?: boolean;
   droppedObjects?: ParsedSkylarkObject[];
   tab: PanelTab;
+  tabState: PanelTabState;
   clearDroppedObjects?: () => void;
   setPanelObject: (o: SkylarkObjectIdentifier) => void;
   setTab: (t: PanelTab) => void;
   navigateToPreviousPanelObject?: () => void;
   navigateToForwardPanelObject?: () => void;
+  updateActivePanelTabState: (s: Partial<PanelTabState>) => void;
 }
 
 const tabsWithDropZones = [PanelTab.Content, PanelTab.Availability];
@@ -173,11 +175,13 @@ export const Panel = ({
   closePanel,
   isDraggedObject,
   droppedObjects,
+  tabState,
   clearDroppedObjects,
   setTab: setSelectedTab,
   navigateToPreviousPanelObject,
   navigateToForwardPanelObject,
   setPanelObject,
+  updateActivePanelTabState,
 }: PanelProps) => {
   useGetObjectPrefetchQueries({
     ...object,
@@ -634,9 +638,11 @@ export const Panel = ({
               setModifiedRelationships={handleRelationshipsObjectsModified}
               inEditMode={inEditMode}
               language={language}
+              tabState={tabState[PanelTab.Relationships]}
               showDropZone={isDraggedObject}
               droppedObjects={droppedObjects}
               setPanelObject={setPanelObject}
+              updateActivePanelTabState={updateActivePanelTabState}
             />
           )}
           {selectedTab === PanelTab.ContentOf && (

--- a/src/components/panel/panel.stories.tsx
+++ b/src/components/panel/panel.stories.tsx
@@ -7,9 +7,15 @@ import GQLSkylarkGetMovieDraftQueryFixture from "src/__tests__/fixtures/skylark/
 import GQLSkylarkGetObjectQueryFixture from "src/__tests__/fixtures/skylark/queries/getObject/fantasticMrFox_All_Availabilities.json";
 import GQLSkylarkGetSeasonQueryFixture from "src/__tests__/fixtures/skylark/queries/getObject/gots04.json";
 import GQLSkylarkGetHomepageSetQueryFixture from "src/__tests__/fixtures/skylark/queries/getObject/homepage.json";
-import { PanelTab } from "src/hooks/state";
+import { PanelTab, PanelTabState } from "src/hooks/state";
 
 import { Panel } from "./panel.component";
+
+const defaultPanelTabState: PanelTabState = {
+  [PanelTab.Relationships]: {
+    expanded: {},
+  },
+};
 
 export default {
   title: "Components/Panel",
@@ -23,6 +29,7 @@ const Template: ComponentStory<typeof Panel> = (args) => {
       {...args}
       closePanel={() => alert("Close clicked")}
       setPanelObject={() => ""}
+      tabState={args.tabState || defaultPanelTabState}
     />
   );
 };

--- a/src/components/panel/panelSections/panelRelationships.component.tsx
+++ b/src/components/panel/panelSections/panelRelationships.component.tsx
@@ -12,6 +12,7 @@ import { PanelSeparator } from "src/components/panel/panelTypography";
 import { Skeleton } from "src/components/skeleton";
 import { OBJECT_LIST_TABLE } from "src/constants/skylark";
 import { useGetObjectRelationships } from "src/hooks/objects/get/useGetObjectRelationships";
+import { PanelTab, PanelTabState } from "src/hooks/state";
 import {
   ParsedSkylarkObjectRelationships,
   SkylarkObjectType,
@@ -27,6 +28,7 @@ interface PanelRelationshipsProps {
   isPage?: boolean;
   objectType: SkylarkObjectType;
   uid: string;
+  tabState: PanelTabState[PanelTab.Relationships];
   modifiedRelationships: Record<
     string,
     { added: ParsedSkylarkObject[]; removed: string[] }
@@ -40,6 +42,7 @@ interface PanelRelationshipsProps {
   droppedObjects?: ParsedSkylarkObject[];
   language: string;
   setPanelObject: (o: SkylarkObjectIdentifier) => void;
+  updateActivePanelTabState: (s: Partial<PanelTabState>) => void;
 }
 
 const sortByRelationshipName = (
@@ -190,7 +193,9 @@ export const PanelRelationships = ({
   language,
   droppedObjects,
   showDropZone,
+  tabState,
   setPanelObject,
+  updateActivePanelTabState,
 }: PanelRelationshipsProps) => {
   const {
     relationships: serverRelationships,
@@ -298,11 +303,15 @@ export const PanelRelationships = ({
                 relationship.relationshipName,
                 modifiedRelationships,
               )}
+              initialExpanded={
+                tabState.expanded?.[relationship.relationshipName]
+              }
               setPanelObject={setPanelObject}
               removeRelationshipObject={({ relationshipName, uid }) => {
                 modifyRelationshipObjects(relationshipName, { removed: [uid] });
               }}
               setSearchObjectsModalState={setSearchObjectsModalState}
+              updateActivePanelTabState={updateActivePanelTabState}
             />
           );
         })}
@@ -318,6 +327,9 @@ export const PanelRelationships = ({
               key={relationship.relationshipName}
               relationship={relationship}
               inEditMode={inEditMode}
+              initialExpanded={
+                tabState.expanded?.[relationship.relationshipName]
+              }
               newUids={getNewUidsForRelationship(
                 relationship.relationshipName,
                 modifiedRelationships,
@@ -327,6 +339,7 @@ export const PanelRelationships = ({
                 modifyRelationshipObjects(relationshipName, { removed: [uid] });
               }}
               setSearchObjectsModalState={setSearchObjectsModalState}
+              updateActivePanelTabState={updateActivePanelTabState}
             />
           );
         })}

--- a/src/components/panel/panelSections/panelRelationshipsSection.component.tsx
+++ b/src/components/panel/panelSections/panelRelationshipsSection.component.tsx
@@ -6,6 +6,7 @@ import {
   PanelSectionTitle,
   PanelSeparator,
 } from "src/components/panel/panelTypography";
+import { PanelTab, PanelTabState } from "src/hooks/state";
 import { useSkylarkObjectOperations } from "src/hooks/useSkylarkObjectTypes";
 import {
   ParsedSkylarkObjectRelationships,
@@ -17,6 +18,7 @@ interface PanelRelationshipsSectionProps {
   relationship: ParsedSkylarkObjectRelationships;
   inEditMode: boolean;
   newUids: string[];
+  initialExpanded: boolean;
   setPanelObject: (o: SkylarkObjectIdentifier) => void;
   removeRelationshipObject: (args: {
     uid: string;
@@ -26,19 +28,31 @@ interface PanelRelationshipsSectionProps {
     relationship: ParsedSkylarkObjectRelationships;
     fields?: string[];
   }) => void;
+  updateActivePanelTabState: (s: Partial<PanelTabState>) => void;
 }
 
 export const PanelRelationshipSection = ({
   relationship,
   inEditMode,
   newUids,
+  initialExpanded,
   setPanelObject,
   removeRelationshipObject,
   setSearchObjectsModalState,
+  updateActivePanelTabState,
 }: PanelRelationshipsSectionProps) => {
   const { relationshipName, objects, objectType } = relationship;
 
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(initialExpanded);
+
+  const toggleExpanded = () => {
+    updateActivePanelTabState({
+      [PanelTab.Relationships]: {
+        expanded: { [relationshipName]: !isExpanded },
+      },
+    });
+    setIsExpanded(!isExpanded);
+  };
 
   const { objectOperations } = useSkylarkObjectOperations(objectType);
   const objectFields = objectOperations?.fields.map(({ name }) => name);
@@ -66,7 +80,7 @@ export const PanelRelationshipSection = ({
             return (
               <Fragment key={`relationship-${obj.objectType}-${obj.uid}`}>
                 <div
-                  className="flex items-center "
+                  className="flex items-center"
                   data-testid={`panel-relationship-${relationshipName}-item-${
                     index + 1
                   }`}
@@ -107,7 +121,7 @@ export const PanelRelationshipSection = ({
           <PanelSeparator />
           <button
             data-testid={`expand-relationship-${relationshipName}`}
-            onClick={() => setIsExpanded(!isExpanded)}
+            onClick={toggleExpanded}
             className="w-full cursor-pointer p-2 text-center text-xs text-manatee-500 hover:text-manatee-700"
           >
             {`Show ${isExpanded ? "less" : "more"}`}

--- a/src/components/panel/panelSections/panelRelationshipsSection.component.tsx
+++ b/src/components/panel/panelSections/panelRelationshipsSection.component.tsx
@@ -61,7 +61,11 @@ export const PanelRelationshipSection = ({
     objects?.length > 2 && !isExpanded ? objects.slice(0, 3) : objects;
 
   return (
-    <div key={relationshipName} className="relative mb-6">
+    <div
+      key={relationshipName}
+      className="relative mb-6"
+      data-testid={relationshipName}
+    >
       <div className="flex items-center ">
         <PanelSectionTitle
           text={formatObjectField(relationshipName)}

--- a/src/components/tabs/tabs.component.tsx
+++ b/src/components/tabs/tabs.component.tsx
@@ -39,29 +39,42 @@ export const Tabs = ({
     >
       {tabs.map((tab, index) => {
         return (
-          <li key={`tab-${tab.id}`} className="relative px-2 md:px-3">
+          <li
+            key={`tab-${tab.id}`}
+            className={clsx(
+              "flex relative border-b-2 -mb-[2px] group/tab-container",
+              onDelete ? "mx-1 md:mx-2" : "mx-2 md:mx-3",
+              !disabled && "hover:border-black hover:text-black",
+              selectedTab === tab.id
+                ? "border-black text-black"
+                : "border-transparent text-gray-400",
+            )}
+          >
             <button
               disabled={disabled}
               onClick={disabled ? undefined : () => onChange({ ...tab, index })}
               className={clsx(
-                "-mb-[2px] w-full whitespace-nowrap rounded-t border-b-2 p-1 pb-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary md:pb-2.5",
-                !disabled && "hover:border-black hover:text-black",
-                selectedTab === tab.id
-                  ? "border-black text-black"
-                  : "border-transparent text-gray-400",
+                "w-full whitespace-nowrap rounded-t  focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary p-1 pb-1.5 pr-0.5 md:pb-2.5",
                 "min-w-10 max-w-52 overflow-hidden text-ellipsis",
               )}
             >
               {tab.name}
             </button>
-            {onDelete && !disabled && selectedTab === tab.id && (
-              <div className="absolute bottom-1.5 right-0.5 top-0 flex w-5/12 justify-end bg-gradient-to-r from-transparent via-white/90 to-white md:top-0.5">
+            {onDelete && !disabled && (
+              <div className="flex justify-end bg-gradient-to-r from-transparent via-white/90 to-white pb-1.5 pt-1 md:pb-2.5">
                 <button
-                  className="group rounded-full p-1 hover:bg-gray-100/20 hover:shadow-inner"
+                  className="group/button rounded-full ml-0.5 p-0.5 hover:bg-gray-100/20 hover:shadow-inner"
                   onClick={() => onDelete({ ...tab, index })}
                   aria-label="delete active tab"
                 >
-                  <FiX className="text-base font-bold text-gray-600 group-hover:text-gray-800" />
+                  <FiX
+                    className={clsx(
+                      "text-base font-bold group-hover/button:text-black",
+                      tab.id === selectedTab
+                        ? "text-gray-600"
+                        : "text-gray-400 group-hover/tab-container:text-gray-600",
+                    )}
+                  />
                 </button>
               </div>
             )}

--- a/src/hooks/objects/delete/useBulkDeleteObjects.tsx
+++ b/src/hooks/objects/delete/useBulkDeleteObjects.tsx
@@ -50,7 +50,6 @@ export const useBulkDeleteObjects = ({
 
   return {
     deleteObjects: mutate,
-    // deleteObjects: (props: any) => console.log("fired"),
     isDeleting: isLoading,
   };
 };

--- a/src/hooks/objects/delete/useBulkDeleteObjects.tsx
+++ b/src/hooks/objects/delete/useBulkDeleteObjects.tsx
@@ -50,6 +50,7 @@ export const useBulkDeleteObjects = ({
 
   return {
     deleteObjects: mutate,
+    // deleteObjects: (props: any) => console.log("fired"),
     isDeleting: isLoading,
   };
 };

--- a/src/hooks/useAccountStatus.tsx
+++ b/src/hooks/useAccountStatus.tsx
@@ -24,7 +24,7 @@ export const useAccountStatus = (poll?: boolean) => {
         activationStatus: data.getActivationStatus,
         backgroundTasks: {
           queued: data.queuedBackgroundTasks.objects,
-          inProgress: data.queuedBackgroundTasks.objects,
+          inProgress: data.inProgressBackgroundTasks.objects,
           failed: data.failedBackgroundTasks.objects,
           hasQueued: data.queuedBackgroundTasks.objects.length > 0,
           hasInProgress: data.inProgressBackgroundTasks.objects.length > 0,

--- a/src/interfaces/skylark/responses.ts
+++ b/src/interfaces/skylark/responses.ts
@@ -42,8 +42,10 @@ export interface GQLSkylarkActivationStatusResponse {
   };
 }
 
-// https://github.com/skylark-platform/skylark/blob/7cf217d549a327ed9139ca11109d086bf577a378/components/object-registry/src/tasks/tasks.py#L20
+// https://github.com/skylark-platform/skylark/blob/d5bbe3624eb5341823975d4068f9332c502607b6/components/object-registry/src/tasks/tasks.py#L24C1-L31C62
 export enum BackgroundTaskType {
+  BATCH_DELETE = "batch_delete",
+  DELETE_POST_PROCESSING = "delete_post_processing",
   POST_CREATE = "post_create",
   POST_UPDATE = "post_update",
   POST_AVAILABILITY_UPDATE = "post_update_availability",

--- a/src/lib/graphql/skylark/client.ts
+++ b/src/lib/graphql/skylark/client.ts
@@ -47,7 +47,6 @@ export const skylarkRequest = <T>(
 
   const headers: HeadersInit = {
     [REQUEST_HEADERS.apiKey]: tokenToSend,
-    [REQUEST_HEADERS.draft]: "true",
     ...argHeaders,
   };
 
@@ -58,6 +57,10 @@ export const skylarkRequest = <T>(
 
   if (bypassCache) {
     headers[REQUEST_HEADERS.bypassCache as keyof HeadersInit] = "1";
+  }
+
+  if (type === "query") {
+    headers[REQUEST_HEADERS.draft as keyof HeadersInit] = "true";
   }
 
   return request<T>(uri || SAAS_API_ENDPOINT, query, variables, headers);

--- a/src/lib/graphql/skylark/mutations.ts
+++ b/src/lib/graphql/skylark/mutations.ts
@@ -1,0 +1,12 @@
+import gql from "graphql-tag";
+
+export const BATCH_DELETE = gql`
+  mutation BATCH_DELETE($objects: [DeleteInput]) {
+    batchDeleteObjects(objects: $objects) {
+      language
+      removed_relationships
+      message
+      task_id
+    }
+  }
+`;

--- a/src/pages/object/[objectType]/[uid].tsx
+++ b/src/pages/object/[objectType]/[uid].tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import { useMemo, useState } from "react";
 
 import { Panel } from "src/components/panel";
-import { PanelTab } from "src/hooks/state";
+import { PanelTab, PanelTabState, mergedPanelTabStates } from "src/hooks/state";
 import { SkylarkObjectIdentifier } from "src/interfaces/skylark";
 
 const Object = () => {
@@ -11,6 +11,12 @@ const Object = () => {
   const { objectType, uid, language } = router.query;
 
   const [tab, setTab] = useState<PanelTab>(PanelTab.Metadata);
+
+  const [tabState, setTabState] = useState<PanelTabState>({
+    [PanelTab.Relationships]: {
+      expanded: {},
+    },
+  });
 
   const object = useMemo(
     () =>
@@ -52,8 +58,14 @@ const Object = () => {
             isPage
             object={object}
             tab={tab}
+            tabState={tabState}
             setPanelObject={setPanelObject}
             setTab={setTab}
+            updateActivePanelTabState={(newTabState) =>
+              setTabState((prevTabState) =>
+                mergedPanelTabStates(prevTabState, newTabState),
+              )
+            }
           />
         </div>
       )}


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->
- Bulk Actions: When you select an object it enables the `Bulk Options` button which currently only contains `Bulk Delete`
  - Bulk Delete: Delete multiple objects at once
- Improved Tab State History: when you expand a relationship and navigate to an object, the relationship will stay expanded.

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Feature

#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://skylarkplatform.atlassian.net/browse/SL-2886

