### PR TITLE
bugfix: Search Filters disappears behind Panel + Column Filter by Object Type

### DIFF
--- a/cypress/e2e/contentLibrary/search.cy.ts
+++ b/cypress/e2e/contentLibrary/search.cy.ts
@@ -176,7 +176,28 @@ describe("Content Library - Search", () => {
     cy.contains("Asset").should("exist");
     cy.get('[aria-label="Open Search Options"]').click();
 
-    const columnsFilters = cy.get("[data-testid=checkbox-grid-columns]");
+    cy.get("#checkbox-sectioned-by-object-types-toggle-all").click();
+
+    const columnsFilters = cy.get("[data-cy=column-filters]");
+
+    cy.contains("Apply").should("be.disabled");
+
+    columnsFilters
+      .get(`#checkbox-columns-special-skylark-ui-display-field`)
+      .click();
+    columnsFilters.get(`#checkbox-columns-special-uid`).click();
+    columnsFilters.get(`#checkbox-columns-skylarkasset-internal_title`).click();
+
+    cy.contains("Apply").should("not.be.disabled").click();
+  });
+
+  it("filters for only title, uid, external_id, title_short fields (old column filters - all fields in a single Checkbox)", () => {
+    cy.contains("Asset").should("exist");
+    cy.get('[aria-label="Open Search Options"]').click();
+
+    cy.get('button[role="switch"]').click({ force: true });
+
+    const columnsFilters = cy.get("[data-cy=column-filters]");
 
     columnsFilters.contains("Toggle all").click();
     cy.contains("Apply").should("be.disabled");
@@ -188,7 +209,7 @@ describe("Content Library - Search", () => {
       "synopsis",
       "synopsis_short",
     ].forEach((field) => {
-      columnsFilters.get(`#checkbox-columns-${field}`).click();
+      columnsFilters.get(`#checkbox-all-fields-${field}`).click();
     });
     cy.contains("Apply").should("not.be.disabled").click();
   });

--- a/cypress/e2e/contentLibrary/tabs.cy.ts
+++ b/cypress/e2e/contentLibrary/tabs.cy.ts
@@ -202,19 +202,16 @@ describe("Content Library - Search", () => {
       cy.contains("Movie").click();
     });
 
-    const columnsFilters = cy.get("[data-testid=checkbox-grid-columns]");
+    const columnsFilters = cy.get("[data-cy=column-filters]");
 
-    columnsFilters.contains("Toggle all").click();
+    cy.get("#checkbox-sectioned-by-object-types-toggle-all").click();
     cy.contains("Apply").should("be.disabled");
-    [
-      "skylark-ui-display-field",
-      "external_id",
-      "title_short",
-      "synopsis",
-      "synopsis_short",
-    ].forEach((field) => {
-      columnsFilters.get(`#checkbox-columns-${field}`).click();
-    });
+
+    columnsFilters
+      .get(`#checkbox-columns-special-skylark-ui-display-field`)
+      .click();
+    columnsFilters.get(`#checkbox-columns-special-external_id`).click();
+    columnsFilters.get(`#checkbox-columns-episode-internal_title`).click();
 
     cy.contains("Apply").click();
 
@@ -299,7 +296,9 @@ describe("Content Library - Search", () => {
     // Select Filters
     cy.get('[aria-label="Open Search Options"]').click();
 
-    const columnsFilters = cy.get("[data-testid=checkbox-grid-columns]");
+    cy.get('button[role="switch"]').click({ force: true });
+
+    const columnsFilters = cy.get("[data-cy=column-filters]");
 
     columnsFilters.contains("Toggle all").click();
     cy.contains("Apply").should("be.disabled");
@@ -310,7 +309,7 @@ describe("Content Library - Search", () => {
       "synopsis",
       "synopsis_short",
     ].forEach((field) => {
-      columnsFilters.get(`#checkbox-columns-${field}`).click();
+      columnsFilters.get(`#checkbox-all-fields-${field}`).click();
     });
 
     cy.contains("Apply").click();

--- a/src/components/checkboxGrid/checkboxGrid.component.tsx
+++ b/src/components/checkboxGrid/checkboxGrid.component.tsx
@@ -1,5 +1,6 @@
 import { CheckedState } from "@radix-ui/react-checkbox";
 import clsx from "clsx";
+import { ElementType } from "react";
 
 import { Checkbox } from "src/components/inputs/checkbox";
 
@@ -13,8 +14,17 @@ export type CheckboxOptionState = {
   state: CheckedState;
 };
 
+interface CheckboxGridToggleAllProps {
+  name: string;
+  options: CheckboxOptionState[];
+  checkedOptions: string[];
+  onChange: (checkedOptions: string[]) => void;
+}
+
 export interface CheckboxGridProps {
-  label?: string;
+  as?: ElementType;
+  label: string;
+  hideLabel?: boolean;
   options: CheckboxOptionState[];
   checkedOptions: string[];
   className?: string;
@@ -34,18 +44,47 @@ export const createCheckboxOptions = (
   );
 };
 
+export const CheckboxGridToggleAll = ({
+  name,
+  options,
+  checkedOptions,
+  onChange,
+}: CheckboxGridToggleAllProps) => {
+  const values = options.map(({ option: { value } }) => value);
+
+  const allOptionsChecked = options.every(({ option }) =>
+    checkedOptions.includes(option.value),
+  );
+
+  const handleToggleAll = () => {
+    onChange(
+      allOptionsChecked
+        ? checkedOptions.filter((option) => !values.includes(option))
+        : [...new Set([...checkedOptions, ...values])],
+    );
+  };
+
+  return (
+    <Checkbox
+      label="Toggle all"
+      className="mb-2"
+      onCheckedChange={handleToggleAll}
+      name={name}
+      checked={allOptionsChecked}
+    />
+  );
+};
+
 export const CheckboxGrid = ({
+  as,
   label,
+  hideLabel,
   className,
   withToggleAll,
   options,
   checkedOptions,
   onChange,
 }: CheckboxGridProps) => {
-  const allOptionsChecked = options.every(({ option }) =>
-    checkedOptions.includes(option.value),
-  );
-
   const handleChange = (option: CheckboxOption, checkedState: CheckedState) => {
     const updatedCheckedOptions = checkedState
       ? [...checkedOptions, option.value]
@@ -53,31 +92,28 @@ export const CheckboxGrid = ({
     onChange(updatedCheckedOptions);
   };
 
-  const handleToggleAll = () => {
-    onChange(
-      allOptionsChecked ? [] : options.map(({ option: { value } }) => value),
-    );
-  };
-
   const handleToggleOnly = (onlyOption: CheckboxOption) => {
     onChange([onlyOption.value]);
   };
 
+  const El = as || "div";
+
   return (
-    <section
+    <El
       className={clsx("flex flex-col text-xs", className)}
       data-testid={`checkbox-grid-${label?.split(" ").join("-").toLowerCase()}`}
     >
-      <h4 className="mb-2 select-none font-semibold text-manatee-600">
-        {label}
-      </h4>
+      {!hideLabel && (
+        <h4 className="mb-2 select-none font-semibold text-manatee-600">
+          {label}
+        </h4>
+      )}
       {withToggleAll && (
-        <Checkbox
-          label="Toggle all"
-          className="mb-2"
-          onCheckedChange={handleToggleAll}
+        <CheckboxGridToggleAll
+          onChange={onChange}
           name={`toggle-all-${label}`}
-          checked={allOptionsChecked}
+          options={options}
+          checkedOptions={checkedOptions}
         />
       )}
       <div className="columns-2 space-y-2 md:columns-4 lg:columns-5 xl:columns-6">
@@ -94,6 +130,6 @@ export const CheckboxGrid = ({
           />
         ))}
       </div>
-    </section>
+    </El>
   );
 };

--- a/src/components/contentLibrary/contentLibrary.component.tsx
+++ b/src/components/contentLibrary/contentLibrary.component.tsx
@@ -245,6 +245,7 @@ export const ContentLibrary = ({
             <div className="absolute inset-0 z-[100] block bg-black/5"></div>
           )}
           <TabbedObjectSearchWithAccount
+            id="content-library-search"
             panelObject={activePanelObject}
             setPanelObject={setPanelObject}
             isPanelOpen={!!activePanelObject}

--- a/src/components/contentLibrary/tabbedObjectSearch/tabbedObjectSearch.test.tsx
+++ b/src/components/contentLibrary/tabbedObjectSearch/tabbedObjectSearch.test.tsx
@@ -38,7 +38,7 @@ const mockLocalStorage = (initialTabs?: ObjectSearchTab[]) => {
 };
 
 const renderWithoutLogoAnimation = async () => {
-  render(<TabbedObjectSearchWithAccount skipLogoAnimation />);
+  render(<TabbedObjectSearchWithAccount skipLogoAnimation id="test" />);
 };
 
 afterEach(() => {
@@ -76,7 +76,7 @@ test("Loads the default tabs when localStorage is empty (verify logo animation d
 test("Changing tabs", async () => {
   mockLocalStorage();
 
-  render(<TabbedObjectSearchWithAccount />);
+  render(<TabbedObjectSearchWithAccount id="test" />);
 
   await waitForElementToBeRemoved(
     () => screen.queryByTestId("animated-skylark-logo"),

--- a/src/components/inputs/switch/switch.component.tsx
+++ b/src/components/inputs/switch/switch.component.tsx
@@ -1,0 +1,54 @@
+import { Switch as HeadlessUiSwitch } from "@headlessui/react";
+import clsx from "clsx";
+import { useState } from "react";
+
+interface SwitchProps {
+  size?: "small";
+  enabled: boolean;
+  onChange: (b: boolean) => void;
+}
+
+const sizeClassNames = {
+  default: {
+    container: "h-6 w-11",
+    dot: "h-4 w-4",
+    translate: {
+      enabled: "translate-x-6",
+      disabled: "translate-x-1",
+    },
+  },
+  small: {
+    container: "h-4 w-6",
+    dot: "h-3 w-3",
+    translate: {
+      enabled: "translate-x-2.5",
+      disabled: "translate-x-0.5",
+    },
+  },
+};
+
+export const Switch = ({ size, enabled, onChange }: SwitchProps) => {
+  const classNames = size ? sizeClassNames[size] : sizeClassNames.default;
+
+  return (
+    <HeadlessUiSwitch
+      checked={enabled}
+      onChange={onChange}
+      className={clsx(
+        "relative inline-flex items-center rounded-full",
+        enabled ? "bg-brand-primary" : "bg-gray-200",
+        classNames.container,
+      )}
+    >
+      <span
+        className={clsx(
+          "inline-block transform rounded-full bg-white transition",
+          classNames.dot,
+          enabled
+            ? classNames.translate.enabled
+            : classNames.translate.disabled,
+        )}
+      />
+    </HeadlessUiSwitch>
+  );
+};

--- a/src/components/inputs/switch/switch.stories.tsx
+++ b/src/components/inputs/switch/switch.stories.tsx
@@ -1,0 +1,34 @@
+import { ComponentStory } from "@storybook/react";
+
+import { Switch } from "./switch.component";
+
+export default {
+  title: "Components/Inputs/Switch",
+  component: Switch,
+};
+
+const Template: ComponentStory<typeof Switch> = (args) => {
+  return <Switch {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  enabled: false,
+};
+
+export const DefaultEnabled = Template.bind({});
+DefaultEnabled.args = {
+  enabled: true,
+};
+
+export const Small = Template.bind({});
+Small.args = {
+  enabled: false,
+  size: "small",
+};
+
+export const SmallEnabled = Template.bind({});
+SmallEnabled.args = {
+  enabled: true,
+  size: "small",
+};

--- a/src/components/inputs/switch/switch.test.tsx
+++ b/src/components/inputs/switch/switch.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent } from "@storybook/testing-library";
+
+import { render, screen } from "src/__tests__/utils/test-utils";
+
+import { Switch } from "./switch.component";
+
+test("renders a falsy Switch", async () => {
+  render(<Switch enabled={false} onChange={jest.fn()} />);
+
+  await screen.findByRole("switch");
+
+  expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+});
+
+test("calls onChange when checked", async () => {
+  const onChange = jest.fn();
+
+  render(<Switch enabled={true} onChange={onChange} />);
+
+  await screen.findByRole("switch");
+  await fireEvent.click(screen.getByRole("switch"));
+
+  expect(onChange).toHaveBeenCalledWith(false);
+  expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+});

--- a/src/components/modals/searchObjectsModal/searchObjectsModal.component.tsx
+++ b/src/components/modals/searchObjectsModal/searchObjectsModal.component.tsx
@@ -67,6 +67,7 @@ export const SearchObjectsModal = ({
     >
       <div className="ml-2 flex-grow overflow-auto pr-0 pt-2 md:ml-4 md:pl-4">
         <ObjectSearch
+          id={`search-object-modal-${objectTypes?.join("-")}`}
           initialFilters={{ objectTypes }}
           initialColumnState={initialColumnState}
           checkedObjects={checkedObjects}

--- a/src/components/objectSearch/objectSearch.component.tsx
+++ b/src/components/objectSearch/objectSearch.component.tsx
@@ -47,6 +47,7 @@ export interface ObjectSearchInitialColumnsState {
 }
 
 export interface ObjectSearchProps {
+  id: string;
   withObjectSelect?: boolean;
   isPanelOpen?: boolean;
   panelObject?: SkylarkObjectIdentifier | null;
@@ -131,6 +132,7 @@ export const ObjectSearch = (props: ObjectSearchProps) => {
   const { defaultLanguage, isLoading: isUserLoading } = useUserAccount();
 
   const {
+    id: tableId,
     setPanelObject,
     isPanelOpen,
     initialSearchType,
@@ -294,6 +296,7 @@ export const ObjectSearch = (props: ObjectSearchProps) => {
     },
     [
       onStateChange,
+      sortedHeaders,
       tableState.columnOrder,
       tableState.columnPinning.left,
       tableState.columnSizing,
@@ -436,6 +439,7 @@ export const ObjectSearch = (props: ObjectSearchProps) => {
           <MemoizedObjectSearchResults
             {...props}
             key={searchHash} // This will rerender all results when the searchHash changes - importantly clearing the checkboxes back to an unchecked state
+            tableId={tableId}
             tableColumns={parsedTableColumns}
             fetchNextPage={fetchNextPage}
             hasNextPage={hasNextPage}

--- a/src/components/objectSearch/objectSearch.component.tsx
+++ b/src/components/objectSearch/objectSearch.component.tsx
@@ -272,6 +272,8 @@ export const ObjectSearch = (props: ObjectSearchProps) => {
         setTableState((prev) => ({
           ...prev,
           columnVisibility: updatedVisibleColumns,
+          // When updating columns, always include any non-ordered columns in the column order or reorder columns breaks
+          columnOrder: [...new Set([...prev.columnOrder, ...sortedHeaders])],
         }));
       }
 

--- a/src/components/objectSearch/objectSearch.test.tsx
+++ b/src/components/objectSearch/objectSearch.test.tsx
@@ -33,7 +33,7 @@ afterEach(() => {
 });
 
 test("renders search bar", () => {
-  render(<ObjectSearch />);
+  render(<ObjectSearch id="test" />);
 
   screen.findByPlaceholderText("Search for an object(s)");
 
@@ -43,7 +43,7 @@ test("renders search bar", () => {
 test("renders search bar, filters with no objects returned", async () => {
   jest.useFakeTimers();
 
-  render(<ObjectSearch />);
+  render(<ObjectSearch id="test" />);
 
   const input = screen.getByPlaceholderText("Search for an object(s)");
   fireEvent.change(input, { target: { value: "AllAvailTestMovie" } });
@@ -60,7 +60,7 @@ test("renders search bar, filters with no objects returned", async () => {
 });
 
 test("renders the info button on row hover when setPanelObject is given", async () => {
-  render(<ObjectSearch setPanelObject={() => ""} />);
+  render(<ObjectSearch id="test" setPanelObject={() => ""} />);
 
   await screen.findAllByText(
     GQLGameOfThronesSearchResultsPage1enGB.data.search.objects[0]
@@ -82,7 +82,7 @@ test("renders the info button on row hover when setPanelObject is given", async 
 });
 
 test("does not render info button on row hover when setPanelObject is undefined", async () => {
-  render(<ObjectSearch setPanelObject={undefined} />);
+  render(<ObjectSearch id="test" setPanelObject={undefined} />);
 
   await screen.findAllByText(
     GQLGameOfThronesSearchResultsPage1enGB.data.search.objects[0]
@@ -106,7 +106,7 @@ test("does not render info button on row hover when setPanelObject is undefined"
 test("calls setPanelObject when the row is clicked", async () => {
   const setPanelObject = jest.fn();
 
-  render(<ObjectSearch setPanelObject={setPanelObject} />);
+  render(<ObjectSearch id="test" setPanelObject={setPanelObject} />);
 
   await screen.findAllByText(
     GQLGameOfThronesSearchResultsPage1enGB.data.search.objects[0]
@@ -126,7 +126,7 @@ test("calls setPanelObject when the row is clicked", async () => {
 test("calls window.open to open the object in a new tab when the row is clicked", async () => {
   window.open = jest.fn();
 
-  render(<ObjectSearch setPanelObject={jest.fn()} />);
+  render(<ObjectSearch id="test" setPanelObject={jest.fn()} />);
 
   const object = GQLGameOfThronesSearchResultsPage1enGB.data.search.objects[0];
 
@@ -144,7 +144,7 @@ test("calls window.open to open the object in a new tab when the row is clicked"
 
 describe("with object select (checkboxes)", () => {
   test("renders row select checkboxes", async () => {
-    await render(<ObjectSearch withObjectSelect />);
+    await render(<ObjectSearch id="test" withObjectSelect />);
 
     const results = await screen.findByTestId("object-search-results-content");
 
@@ -156,7 +156,7 @@ describe("with object select (checkboxes)", () => {
   });
 
   test("bulk options are disabled when nothing is checked", async () => {
-    await render(<ObjectSearch withObjectSelect />);
+    await render(<ObjectSearch id="test" withObjectSelect />);
 
     const results = await screen.findByTestId("object-search-results-content");
 
@@ -174,6 +174,7 @@ describe("with object select (checkboxes)", () => {
 
     await render(
       <ObjectSearch
+        id="test"
         withObjectSelect
         onObjectCheckedChanged={onRowCheckChange}
         checkedObjects={[]}
@@ -202,6 +203,7 @@ describe("with object select (checkboxes)", () => {
 
     await render(
       <ObjectSearch
+        id="test"
         withObjectSelect
         onObjectCheckedChanged={onObjectCheckedChanged}
       />,
@@ -231,6 +233,7 @@ describe("with object select (checkboxes)", () => {
 
     await render(
       <ObjectSearch
+        id="test"
         withObjectSelect
         onObjectCheckedChanged={onRowCheckChange}
         checkedObjects={[
@@ -259,6 +262,7 @@ describe("with object select (checkboxes)", () => {
   test("bulk options are enabled when objects are checked", async () => {
     await render(
       <ObjectSearch
+        id="test"
         withObjectSelect
         checkedObjects={[
           {
@@ -281,7 +285,7 @@ describe("with object select (checkboxes)", () => {
 });
 
 test("renders search results (with default language)", async () => {
-  render(<ObjectSearch />);
+  render(<ObjectSearch id="test" />);
 
   await screen.findByText("Display field"); // Search for table header
   await waitFor(() => {
@@ -319,7 +323,7 @@ test("renders search results with language as null (no default)", async () => {
     }),
   );
 
-  render(<ObjectSearch />);
+  render(<ObjectSearch id="test" />);
 
   await screen.findByText("Display field"); // Search for table header
   // Search for table content
@@ -337,7 +341,7 @@ test("renders search results with language as null (no default)", async () => {
 });
 
 test("opens filters and deselects all object types", async () => {
-  render(<ObjectSearch initialColumnState={{ columns: ["uid"] }} />);
+  render(<ObjectSearch id="test" initialColumnState={{ columns: ["uid"] }} />);
 
   await screen.findByText("Display field"); // Search for table header
 
@@ -379,6 +383,7 @@ test("manually filters to only en-gb translated objects", async () => {
 
   render(
     <ObjectSearch
+      id="test"
       initialColumnState={{
         columns: ["uid", OBJECT_LIST_TABLE.columnIds.translation],
       }}
@@ -429,6 +434,7 @@ test("manually filters to only en-gb translated objects", async () => {
 test("automatically filters to only en-gb translated objects as its the user/account's default language", async () => {
   await render(
     <ObjectSearch
+      id="test"
       initialColumnState={{
         columns: ["uid", OBJECT_LIST_TABLE.columnIds.translation],
       }}
@@ -461,6 +467,7 @@ test("clears the language filter", async () => {
   // Arrange
   render(
     <ObjectSearch
+      id="test"
       initialColumnState={{
         columns: ["uid", OBJECT_LIST_TABLE.columnIds.translation],
       }}
@@ -519,6 +526,7 @@ describe("batch options", () => {
   test("opens delete objects modal", async () => {
     await render(
       <ObjectSearch
+        id="test"
         withObjectSelect
         checkedObjects={[
           {

--- a/src/components/objectSearch/results/grids/grids.tsx
+++ b/src/components/objectSearch/results/grids/grids.tsx
@@ -39,6 +39,7 @@ import { LayoutRow } from "./rows";
 
 interface GridProps {
   table: Table<ParsedSkylarkObject>;
+  tableId: string;
   totalVirtualSizes: { height: number; width: number };
   rows: Row<ParsedSkylarkObject>[];
   virtualRows: VirtualItem[];
@@ -128,6 +129,7 @@ const GridSkeleton = ({
 
 export const ObjectSearchResultsLeftGrid = ({
   table,
+  tableId,
   totalVirtualSizes,
   virtualRows,
   leftGridSize: width,
@@ -170,6 +172,7 @@ export const ObjectSearchResultsLeftGrid = ({
     >
       {showFrozenColumnDropZones && (
         <FrozenColumnDropzone
+          tableId={tableId}
           columnId={unfreezeAllDropzone.id}
           height={totalVirtualSizes.height}
           leftGridSize={0}
@@ -178,6 +181,7 @@ export const ObjectSearchResultsLeftGrid = ({
         />
       )}
       <FrozenColumnDropzones
+        tableId={tableId}
         show={showFrozenColumnDropZones}
         dropzoneColumns={unfreezableVirtualColumns}
         leftGridSize={0}
@@ -210,6 +214,7 @@ export const ObjectSearchResultsLeftGrid = ({
           return (
             <HeaderCell
               key={`left-grid-header-${header.id}`}
+              tableId={tableId}
               header={header}
               virtualColumn={virtualColumn}
               onMouseEnter={() => setHoveredRow?.(null)}
@@ -228,6 +233,7 @@ export const ObjectSearchResultsLeftGrid = ({
         return (
           <LayoutRow
             key={key}
+            tableId={tableId}
             row={row}
             virtualRow={virtualRow}
             virtualColumns={virtualColumns}
@@ -271,9 +277,11 @@ const FrozenColumnDragPill = ({
 );
 
 export const ObjectSearchResultGridDivider = ({
+  tableId,
   leftGridSize,
   totalVirtualSizes,
 }: {
+  tableId: string;
   leftGridSize: number;
   totalVirtualSizes: { height: number; width: number };
 }) => {
@@ -282,7 +290,7 @@ export const ObjectSearchResultGridDivider = ({
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useDraggable({
       type: DragType.OBJECT_SEARCH_MODIFY_FROZEN_COLUMNS,
-      id: "MODIFY_FROZEN_COLUMNS",
+      id: `${tableId}-MODIFY_FROZEN_COLUMNS`,
       options: {
         modifiers: [snapCenterToCursor],
         dragOverlay: <FrozenColumnDragPill isDragging />,
@@ -339,12 +347,14 @@ export const ObjectSearchResultGridDivider = ({
 };
 
 const FrozenColumnDropzone = ({
+  tableId,
   columnId,
   height,
   width,
   virtualColumn,
   leftGridSize,
 }: {
+  tableId: string;
   columnId: string;
   height: number;
   width: number;
@@ -353,7 +363,7 @@ const FrozenColumnDropzone = ({
 }) => {
   const { isOver, setNodeRef } = useDroppable({
     type: DragType.OBJECT_SEARCH_MODIFY_FROZEN_COLUMNS,
-    id: `FROZEN_COLUMN_${virtualColumn.index}`,
+    id: `${tableId}-FROZEN_COLUMN_${virtualColumn.index}`,
     data: {
       columnId,
     },
@@ -381,6 +391,7 @@ const FrozenColumnDropzones = ({
   headers,
   ...props
 }: {
+  tableId: string;
   height: number;
   dropzoneColumns: VirtualItem[];
   leftGridSize: number;
@@ -413,6 +424,7 @@ const FrozenColumnDropzones = ({
 
 export const ObjectSearchResultsRightGrid = ({
   table,
+  tableId,
   totalVirtualSizes,
   rows,
   virtualRows,
@@ -462,6 +474,7 @@ export const ObjectSearchResultsRightGrid = ({
   return (
     <div className="relative" data-testid="object-search-results-grid-right">
       <FrozenColumnDropzones
+        tableId={tableId}
         show={showFrozenColumnDropZones}
         dropzoneColumns={virtualColumns.slice(
           0,
@@ -503,6 +516,7 @@ export const ObjectSearchResultsRightGrid = ({
             return (
               <HeaderCell
                 key={key}
+                tableId={tableId}
                 header={header}
                 virtualColumn={virtualColumn}
                 paddingLeft={leftGridSize}
@@ -526,6 +540,7 @@ export const ObjectSearchResultsRightGrid = ({
           <LayoutRow
             key={key}
             row={row}
+            tableId={tableId}
             virtualRow={virtualRow}
             virtualColumns={virtualColumns}
             panelObject={panelObject}

--- a/src/components/objectSearch/results/grids/headers.tsx
+++ b/src/components/objectSearch/results/grids/headers.tsx
@@ -8,12 +8,14 @@ import { ParsedSkylarkObject } from "src/interfaces/skylark";
 import { DragType, useDraggable, useDroppable } from "src/lib/dndkit/dndkit";
 
 export const HeaderCell = ({
+  tableId,
   header,
   virtualColumn,
   paddingLeft = 0,
   isDraggable,
   onMouseEnter,
 }: {
+  tableId: string;
   header: Header<ParsedSkylarkObject, string>;
   virtualColumn: VirtualItem;
   paddingLeft?: number;
@@ -24,7 +26,7 @@ export const HeaderCell = ({
 
   const { setNodeRef: setDropRef } = useDroppable({
     type: DragType.OBJECT_SEARCH_REORDER_COLUMNS,
-    id: `drop-${column.id}`,
+    id: `${tableId}-column-reorder-drop-${column.id}`,
     data: {
       column,
     },
@@ -33,7 +35,7 @@ export const HeaderCell = ({
 
   const { attributes, listeners, setNodeRef } = useDraggable({
     type: DragType.OBJECT_SEARCH_REORDER_COLUMNS,
-    id: `drag-${column.id}`,
+    id: `${tableId}-column-reorder-drag-${column.id}`,
     data: {
       column,
     },

--- a/src/components/objectSearch/results/grids/headers.tsx
+++ b/src/components/objectSearch/results/grids/headers.tsx
@@ -60,7 +60,7 @@ export const HeaderCell = ({
       <div
         ref={setDropRef}
         className={clsx("absolute bottom-0 left-0 right-0 top-0")}
-      ></div>
+      />
       <div
         ref={setNodeRef}
         {...listeners}

--- a/src/components/objectSearch/results/grids/rows.tsx
+++ b/src/components/objectSearch/results/grids/rows.tsx
@@ -13,6 +13,7 @@ import { DragType, useDraggable } from "src/lib/dndkit/dndkit";
 import { convertParsedObjectToIdentifier } from "src/lib/skylark/objects";
 
 interface DataRowProps {
+  tableId: string;
   virtualRow: VirtualItem;
   row: Row<ParsedSkylarkObject>;
   virtualColumns: VirtualItem[];
@@ -27,16 +28,17 @@ interface LayoutRowProps extends DataRowProps {
 }
 
 const DataRow = ({
+  tableId,
   virtualRow,
   row,
   virtualColumns,
   isDraggable,
   isLeft,
 }: DataRowProps & { isDraggable: boolean }) => {
-  const draggableId = `row-${row.id}-${isLeft ? "left" : ""}`;
+  const draggableId = `${tableId}-row-${row.id}-${isLeft ? "left" : ""}`;
   const { attributes, listeners, setNodeRef } = useDraggable({
     type: DragType.CONTENT_LIBRARY_OBJECT,
-    id: `row-${row.id}-${isLeft ? "left" : ""}`,
+    id: draggableId,
     data: {
       object: row.original,
     },

--- a/src/components/objectSearch/results/objectSearchResults.component.tsx
+++ b/src/components/objectSearch/results/objectSearchResults.component.tsx
@@ -276,13 +276,7 @@ export const ObjectSearchResults = ({
     },
   });
 
-  const visibleColumns = table
-    .getVisibleFlatColumns()
-    .sort(
-      (a, b) =>
-        tableState.columnOrder.indexOf(a.id) -
-        tableState.columnOrder.indexOf(b.id),
-    );
+  const visibleColumns = table.getVisibleLeafColumns();
 
   const frozenColumnsParsedColumnsIndexes = useMemo(
     () =>
@@ -376,11 +370,7 @@ export const ObjectSearchResults = ({
         const dropzoneColumnId = event.over?.data.current?.columnId;
         if (dropzoneColumnId) {
           // When the frozen columns are changed, unfreeze any hidden columns and move to the right of the frozen columns
-          const orderedVisibleColumns = [...visibleColumns].sort(
-            (a, b) =>
-              tableState.columnOrder.indexOf(a.id) -
-              tableState.columnOrder.indexOf(b.id),
-          );
+          const orderedVisibleColumns = [...visibleColumns];
 
           const columnIndex = orderedVisibleColumns.findIndex(
             (col) => col.id === dropzoneColumnId,

--- a/src/components/objectSearch/results/objectSearchResults.component.tsx
+++ b/src/components/objectSearch/results/objectSearchResults.component.tsx
@@ -39,6 +39,7 @@ import {
 } from "./grids";
 
 export interface ObjectSearchResultsProps {
+  tableId: string;
   tableColumns: ColumnDef<ParsedSkylarkObject, ParsedSkylarkObject>[];
   withCreateButtons?: boolean;
   withObjectSelect?: boolean;
@@ -77,6 +78,7 @@ const splitVirtualColumns = (
 };
 
 export const ObjectSearchResults = ({
+  tableId,
   tableColumns,
   tableState,
   panelObject,
@@ -449,6 +451,7 @@ export const ObjectSearchResults = ({
             {virtualColumns.left.length > 0 && (
               <ObjectSearchResultsLeftGrid
                 table={table}
+                tableId={tableId}
                 virtualColumns={virtualColumns.left}
                 virtualRows={rowVirtualizer.virtualItems}
                 headers={headers}
@@ -470,12 +473,14 @@ export const ObjectSearchResults = ({
               />
             )}
             <ObjectSearchResultGridDivider
+              tableId={tableId}
               leftGridSize={leftGridTotalSize}
               totalVirtualSizes={totalVirtualSizes}
             />
             {virtualColumns.right.length > 0 && (
               <ObjectSearchResultsRightGrid
                 table={table}
+                tableId={tableId}
                 totalVirtualSizes={totalVirtualSizes}
                 hasScrolledRight={hasScrolledRight}
                 virtualColumns={virtualColumns.right}

--- a/src/components/objectSearch/search/search.component.tsx
+++ b/src/components/objectSearch/search/search.component.tsx
@@ -93,7 +93,7 @@ export const Search = ({
 
   const { refs, floatingStyles, context } = useFloating({
     open: isFilterOpen,
-    placement: "bottom",
+    placement: "bottom-start",
     middleware: [offset(5), flip(), shift({ padding: 5 })],
     whileElementsMounted: autoUpdate,
     onOpenChange: setFilterOpen,

--- a/src/components/objectSearch/search/search.stories.tsx
+++ b/src/components/objectSearch/search/search.stories.tsx
@@ -46,7 +46,11 @@ const visibleColumns: VisibilityState = Object.fromEntries(
 );
 
 const Template: ComponentStory<typeof Search> = (args) => {
-  return <Search {...args} />;
+  return (
+    <div className="w-full h-[500px]">
+      <Search {...args} />
+    </div>
+  );
 };
 
 export const Default = Template.bind({});

--- a/src/components/objectSearch/search/searchFilter/searchFilter.component.tsx
+++ b/src/components/objectSearch/search/searchFilter/searchFilter.component.tsx
@@ -1,17 +1,27 @@
 import { VisibilityState } from "@tanstack/react-table";
 import { DocumentNode } from "graphql";
 import { useMemo, useState } from "react";
+import { useLocalStorage } from "usehooks-ts";
 
 import { Button } from "src/components/button";
 import {
   CheckboxGrid,
+  CheckboxGridToggleAll,
   createCheckboxOptions,
 } from "src/components/checkboxGrid/checkboxGrid.component";
 import { RadioGroup } from "src/components/inputs/radioGroup/radioGroup.component";
+import { Switch } from "src/components/inputs/switch/switch.component";
 import { DisplayGraphQLQuery } from "src/components/modals";
+import { LOCAL_STORAGE } from "src/constants/localStorage";
+import { SYSTEM_FIELDS } from "src/constants/skylark";
 import { SearchFilters } from "src/hooks/useSearch";
 import { SearchType } from "src/hooks/useSearchWithLookupType";
+import {
+  sortObjectTypesWithConfig,
+  useAllObjectsMeta,
+} from "src/hooks/useSkylarkObjectTypes";
 import { ParsedSkylarkObjectConfig } from "src/interfaces/skylark";
+import { sortFieldsByConfigPosition } from "src/lib/skylark/objects";
 
 interface SearchFilterProps {
   searchType: SearchType;
@@ -55,6 +65,160 @@ const searchTypeOptions = [
     value: SearchType.UIDExtIDLookup,
   },
 ];
+
+const FilterColumns = ({
+  objectTypes,
+  columns,
+  updatedVisibleColumns,
+  objectTypesWithConfig,
+  updateVisibleColumns,
+}: {
+  columns: SearchFilterProps["columns"];
+  updatedVisibleColumns: SearchFilterProps["visibleColumns"];
+  objectTypes: string[];
+  objectTypesWithConfig: SearchFilterProps["objectTypesWithConfig"];
+  updateVisibleColumns: (arr: string[]) => void;
+}) => {
+  const { objects: allObjectsMeta } = useAllObjectsMeta();
+
+  const [sectionByObjectType, setSectionByObjectType] = useLocalStorage(
+    LOCAL_STORAGE.search.columnFilterVariant,
+    true,
+  );
+
+  const allColumnOptions = useMemo(
+    () =>
+      createCheckboxOptions(
+        columns.map(({ label, value }) => ({ label: label || value, value })),
+        updatedVisibleColumns,
+      ),
+    [columns, updatedVisibleColumns],
+  );
+
+  const { columnOptionsSplitByObjectType, commonFieldOptions } = useMemo(() => {
+    const columnOptionsSplitByObjectType = allObjectsMeta
+      ?.map((objectMeta) => {
+        const config = objectTypesWithConfig.find(
+          ({ objectType }) => objectType === objectMeta.name,
+        )?.config;
+
+        const options = createCheckboxOptions(
+          objectMeta.fields
+            .filter(({ name }) => !SYSTEM_FIELDS?.includes(name))
+            .sort((a, b) =>
+              sortFieldsByConfigPosition(a.name, b.name, config?.fieldConfig),
+            )
+            .map(({ name }) => {
+              const columnField = columns.find(({ value }) => value === name);
+
+              return {
+                value: columnField?.value || name,
+                label: columnField?.label || columnField?.value || name,
+              };
+            }),
+          updatedVisibleColumns,
+        );
+
+        return {
+          objectType: objectMeta.name,
+          config,
+          options,
+        };
+      })
+      .sort(sortObjectTypesWithConfig);
+
+    const allObjectFields =
+      allObjectsMeta
+        ?.map((objectMeta) => objectMeta.fields.map(({ name }) => name))
+        .flatMap((arr) => arr) || [];
+    const unassignedColumns = columns
+      .filter(
+        ({ value }) =>
+          !allObjectFields.includes(value) || SYSTEM_FIELDS.includes(value),
+      )
+      .map(({ value, label }) => ({ value, label: label || value }));
+
+    const commonFieldOptions = createCheckboxOptions(
+      unassignedColumns || [],
+      updatedVisibleColumns,
+    );
+
+    return {
+      commonFieldOptions,
+      columnOptionsSplitByObjectType,
+    };
+  }, [allObjectsMeta, columns, objectTypesWithConfig, updatedVisibleColumns]);
+
+  return (
+    <section>
+      <div className="flex mb-2 text-manatee-600 justify-between">
+        <h4 className="select-none font-semibold mr-2">Columns</h4>
+        <div className="flex justify-center">
+          <p className="select-none block mx-1">{`${
+            sectionByObjectType ? "Separated by Object Type" : "All fields"
+          }`}</p>
+          <Switch
+            enabled={sectionByObjectType}
+            onChange={setSectionByObjectType}
+            size="small"
+          />
+        </div>
+      </div>
+      {sectionByObjectType ? (
+        <>
+          <CheckboxGridToggleAll
+            onChange={updateVisibleColumns}
+            name={`sectioned-by-object-types-toggle-all`}
+            options={allColumnOptions}
+            checkedOptions={updatedVisibleColumns}
+          />
+          <div>
+            <h4 className="mb-2 select-none text-manatee-500">
+              System & Special Columns
+            </h4>
+            <CheckboxGrid
+              label="special"
+              hideLabel
+              withToggleAll
+              className="mt-2"
+              options={commonFieldOptions}
+              checkedOptions={updatedVisibleColumns}
+              onChange={updateVisibleColumns}
+            />
+          </div>
+          {columnOptionsSplitByObjectType
+            ?.filter(({ objectType }) => objectTypes.includes(objectType))
+            .map(({ objectType, config, options }) => (
+              <div key={objectType} className="mt-2">
+                <h4 className="mb-2 select-none text-manatee-500">
+                  {config?.objectTypeDisplayName || objectType} fields
+                </h4>
+                <CheckboxGrid
+                  label={objectType}
+                  hideLabel
+                  withToggleAll
+                  options={options}
+                  checkedOptions={updatedVisibleColumns}
+                  onChange={updateVisibleColumns}
+                />
+              </div>
+            ))}
+        </>
+      ) : (
+        <CheckboxGrid
+          label="all fields"
+          hideLabel
+          withToggleAll
+          options={allColumnOptions}
+          checkedOptions={updatedVisibleColumns}
+          onChange={(checkedOptions) => {
+            updateVisibleColumns(checkedOptions);
+          }}
+        />
+      )}
+    </section>
+  );
+};
 
 export const SearchFilter = ({
   searchType: activeSearchType,
@@ -116,15 +280,6 @@ export const SearchFilter = ({
     [objectTypesWithConfig, updatedObjectTypes],
   );
 
-  const columnOptions = useMemo(
-    () =>
-      createCheckboxOptions(
-        columns.map(({ label, value }) => ({ label: label || value, value })),
-        updatedVisibleColumns,
-      ),
-    [columns, updatedVisibleColumns],
-  );
-
   return (
     <div className="relative flex max-h-[60vh] w-full flex-col rounded bg-white py-2 text-xs shadow-lg shadow-manatee-500 md:max-h-96 xl:max-h-[28rem]">
       <div className="absolute right-5 top-2 z-20">
@@ -145,6 +300,7 @@ export const SearchFilter = ({
         />
         <CheckboxGrid
           label="Object type"
+          as="section"
           withToggleAll
           options={objectTypeOptions}
           checkedOptions={updatedObjectTypes}
@@ -152,14 +308,12 @@ export const SearchFilter = ({
             updateObjectTypes(checkedOptions);
           }}
         />
-        <CheckboxGrid
-          label="Columns"
-          withToggleAll
-          options={columnOptions}
-          checkedOptions={updatedVisibleColumns}
-          onChange={(checkedOptions) => {
-            updateVisibleColumns(checkedOptions);
-          }}
+        <FilterColumns
+          objectTypes={updatedObjectTypes}
+          objectTypesWithConfig={objectTypesWithConfig}
+          columns={columns}
+          updateVisibleColumns={updateVisibleColumns}
+          updatedVisibleColumns={updatedVisibleColumns}
         />
       </div>
       <div className="flex w-full justify-end space-x-4 px-4 pt-2">

--- a/src/components/objectSearch/search/searchFilter/searchFilter.component.tsx
+++ b/src/components/objectSearch/search/searchFilter/searchFilter.component.tsx
@@ -150,7 +150,7 @@ const FilterColumns = ({
   }, [allObjectsMeta, columns, objectTypesWithConfig, updatedVisibleColumns]);
 
   return (
-    <section>
+    <section data-cy="column-filters">
       <div className="flex mb-2 text-manatee-600 justify-between">
         <h4 className="select-none font-semibold mr-2">Columns</h4>
         <div className="flex justify-center">
@@ -177,7 +177,7 @@ const FilterColumns = ({
               System & Special Columns
             </h4>
             <CheckboxGrid
-              label="special"
+              label="columns-special"
               hideLabel
               withToggleAll
               className="mt-2"
@@ -194,7 +194,7 @@ const FilterColumns = ({
                   {config?.objectTypeDisplayName || objectType} fields
                 </h4>
                 <CheckboxGrid
-                  label={objectType}
+                  label={`columns-${objectType}`}
                   hideLabel
                   withToggleAll
                   options={options}

--- a/src/components/objectSearch/search/searchFilter/searchFilter.test.tsx
+++ b/src/components/objectSearch/search/searchFilter/searchFilter.test.tsx
@@ -83,6 +83,50 @@ test("changes checkboxes and calls onFilterSave when apply is clicked", async ()
   });
 });
 
+test("changes checkboxes and calls onFilterSave when apply is clicked (old column filter - all fields in a single CheckboxGrid)", async () => {
+  const onFilterSave = jest.fn();
+
+  render(
+    <SearchFilter
+      searchType={SearchType.Search}
+      objectTypesWithConfig={objectTypesWithConfig}
+      activeObjectTypes={objectTypes}
+      columns={columnOpts}
+      visibleColumns={columns}
+      onFilterSave={onFilterSave}
+      graphqlQuery={graphqlQuery}
+    />,
+  );
+
+  await screen.findAllByRole("checkbox");
+
+  const columnFilterSwitch = await screen.findByRole("switch");
+  fireEvent.click(columnFilterSwitch);
+
+  const seasonCheckbox = await screen.findByRole("checkbox", {
+    name: "Season",
+  });
+  await fireEvent.click(seasonCheckbox);
+
+  const slugCheckbox = await screen.findByRole("checkbox", { name: "slug" });
+  await fireEvent.click(slugCheckbox);
+
+  const uidLookup = await screen.findByText("UID & External ID");
+  await fireEvent.click(uidLookup);
+
+  await fireEvent.click(await screen.findByText("Apply"));
+
+  expect(onFilterSave).toHaveBeenCalledWith({
+    filters: { objectTypes: ["Brand", "Episode"] },
+    columnVisibility: {
+      external_id: true,
+      slug: false,
+      uid: true,
+    },
+    searchType: SearchType.UIDExtIDLookup,
+  });
+});
+
 test("when reset is clicked, all filters are returned to all options checked without saving", async () => {
   const onFilterSave = jest.fn();
 

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -25,4 +25,7 @@ export const LOCAL_STORAGE = {
     variables: "graphiql:variables",
     headers: "graphiql:headers",
   },
+  search: {
+    columnFilterVariant: "skylark:search:filter:column",
+  },
 };

--- a/src/hooks/useSkylarkObjectTypes.ts
+++ b/src/hooks/useSkylarkObjectTypes.ts
@@ -5,6 +5,7 @@ import { useCallback, useMemo } from "react";
 import { QueryKeys } from "src/enums/graphql";
 import {
   GQLSkylarkObjectTypesWithConfig,
+  ParsedSkylarkObjectConfig,
   SkylarkObjectMeta,
   SkylarkObjectType,
 } from "src/interfaces/skylark";
@@ -22,6 +23,25 @@ import {
   useSkylarkSchemaInterfaceType,
   useSkylarkSchemaIntrospection,
 } from "./useSkylarkSchemaIntrospection";
+
+export const sortObjectTypesWithConfig = (
+  a: {
+    objectType: string;
+    config?: ParsedSkylarkObjectConfig;
+  },
+  b: {
+    objectType: string;
+    config?: ParsedSkylarkObjectConfig;
+  },
+) => {
+  const objTypeA = (
+    a.config?.objectTypeDisplayName || a.objectType
+  ).toUpperCase();
+  const objTypeB = (
+    b.config?.objectTypeDisplayName || b.objectType
+  ).toUpperCase();
+  return objTypeA < objTypeB ? -1 : objTypeA > objTypeB ? 1 : 0;
+};
 
 export const useSkylarkObjectTypes = (searchable: boolean) => {
   // VisibleObject Interface contains all items that appear in Search, whereas Metadata can all be added into Sets
@@ -61,15 +81,7 @@ const useObjectTypesConfig = (objectTypes?: string[]) => {
           objectType,
           config: parseObjectConfig(objectType, data?.[objectType]),
         }))
-        .sort((a, b) => {
-          const objTypeA = (
-            a.config.objectTypeDisplayName || a.objectType
-          ).toUpperCase();
-          const objTypeB = (
-            b.config.objectTypeDisplayName || b.objectType
-          ).toUpperCase();
-          return objTypeA < objTypeB ? -1 : objTypeA > objTypeB ? 1 : 0;
-        }),
+        .sort(sortObjectTypesWithConfig),
     [data, objectTypes],
   );
 

--- a/src/lib/skylark/objects.ts
+++ b/src/lib/skylark/objects.ts
@@ -509,9 +509,9 @@ export const getAllObjectsMeta = (
   return objectOperations;
 };
 
-const sortFieldsByConfigPosition = (
-  { field: fieldA }: { field: string },
-  { field: fieldB }: { field: string },
+export const sortFieldsByConfigPosition = (
+  fieldA: string,
+  fieldB: string,
   objectFieldConfig?: ParsedSkylarkObjectConfig["fieldConfig"],
 ) => {
   const aFieldConfig = objectFieldConfig?.find(({ name }) => fieldA === name);
@@ -581,10 +581,14 @@ export const splitMetadataIntoSystemTranslatableGlobal = (
 
   const globalMetadataFields = otherFields
     .filter(({ field }) => fieldConfig.global.includes(field))
-    .sort((a, b) => sortFieldsByConfigPosition(a, b, objectFieldConfig));
+    .sort((a, b) =>
+      sortFieldsByConfigPosition(a.field, b.field, objectFieldConfig),
+    );
   const translatableMetadataFields = otherFields
     .filter(({ field }) => fieldConfig.translatable.includes(field))
-    .sort((a, b) => sortFieldsByConfigPosition(a, b, objectFieldConfig));
+    .sort((a, b) =>
+      sortFieldsByConfigPosition(a.field, b.field, objectFieldConfig),
+    );
 
   return {
     systemMetadataFields,


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->

- Fixes a bug where the search filter would disappear behind the Panel making it unusable
- Fixes (hopefully) the bug where rows would become un-draggable
- Adds a new way to filter columns by sectioning the columns by Object Type

Also: 
- Tweaks the object search to remove sorting and use react-table to sort the frozen columns (slight bugfix)

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Bugfix
* [x] Feature

#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://skylarkplatform.atlassian.net/browse/SL-2821
https://skylarkplatform.atlassian.net/browse/SL-2891

