### PR TITLE
fix: null external_id in CSV importer

### DIFF
--- a/src/lib/flatfile/import.ts
+++ b/src/lib/flatfile/import.ts
@@ -95,6 +95,7 @@ export const createFlatfileObjectsInSkylark = async (
               objectType,
               data,
               skylarkObjectOperations.create.inputs,
+              true,
             );
 
             const operation = {

--- a/src/lib/graphql/skylark/dynamicMutations/objects.ts
+++ b/src/lib/graphql/skylark/dynamicMutations/objects.ts
@@ -91,15 +91,8 @@ export const createCreateObjectMutation = (
     objectMeta.name,
     metadata,
     objectMeta.operations.update.inputs,
+    true,
   );
-
-  // Don't send a blank External ID
-  if (
-    hasProperty(parsedMetadata, SkylarkSystemField.ExternalID) &&
-    !parsedMetadata.external_id
-  ) {
-    delete parsedMetadata.external_id;
-  }
 
   const common = generateVariablesAndArgs(
     objectMeta.name,

--- a/src/lib/skylark/parsers.test.ts
+++ b/src/lib/skylark/parsers.test.ts
@@ -842,6 +842,26 @@ describe("parseMetadataForGraphQLRequest", () => {
     });
   });
 
+  test("removes a blank external_id from the parsedMetadata when create is true", () => {
+    const metadata: Record<string, SkylarkObjectMetadataField> = {
+      title: "",
+      date: "",
+      int: null,
+      [SkylarkSystemField.ExternalID]: "",
+    };
+    const got = parseMetadataForGraphQLRequest(
+      objectType,
+      metadata,
+      inputFields,
+      true,
+    );
+    expect(got).toEqual({
+      title: null,
+      date: null,
+      int: null,
+    });
+  });
+
   test("returns metadata with formatted values", () => {
     const metadata: Record<string, SkylarkObjectMetadataField> = {
       title: "string",

--- a/src/lib/skylark/parsers.ts
+++ b/src/lib/skylark/parsers.ts
@@ -465,11 +465,17 @@ export const parseMetadataForGraphQLRequest = (
   objectType: SkylarkObjectType,
   metadata: Record<string, SkylarkObjectMetadataField>,
   inputFields: NormalizedObjectField[],
+  isCreate?: boolean,
 ) => {
   const keyValuePairs = Object.entries(metadata)
     .map(([key, value]) => {
       // Never send UID as it cannot be changed
       if (key === SkylarkSystemField.UID) {
+        return undefined;
+      }
+
+      // Never send blank ExternalID on create
+      if (key === SkylarkSystemField.ExternalID && isCreate && !value) {
         return undefined;
       }
 


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->

- CSV importer is broken as it tries to send `external_id: null` when one isn't given. I broke this a few weeks ago when enabling sending `external_id: null` on update.

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Bugfix


