### PR TITLE
fix: only set column order when its actually set

### DIFF
--- a/src/components/objectSearch/objectSearch.component.tsx
+++ b/src/components/objectSearch/objectSearch.component.tsx
@@ -271,12 +271,19 @@ export const ObjectSearch = (props: ObjectSearchProps) => {
       }
 
       if (updatedVisibleColumns) {
-        setTableState((prev) => ({
-          ...prev,
-          columnVisibility: updatedVisibleColumns,
-          // When updating columns, always include any non-ordered columns in the column order or reorder columns breaks
-          columnOrder: [...new Set([...prev.columnOrder, ...sortedHeaders])],
-        }));
+        setTableState((prev) => {
+          const newColumnOrder =
+            prev.columnOrder.length > 0
+              ? [...new Set([...prev.columnOrder, ...sortedHeaders])]
+              : prev.columnOrder;
+          console.log({ prev, newColumnOrder, updatedVisibleColumns });
+          return {
+            ...prev,
+            columnVisibility: updatedVisibleColumns,
+            // When updating columns, always include any non-ordered columns in the column order or reorder columns breaks
+            columnOrder: newColumnOrder,
+          };
+        });
       }
 
       if (searchType) {

--- a/src/components/objectSearch/objectSearch.component.tsx
+++ b/src/components/objectSearch/objectSearch.component.tsx
@@ -272,6 +272,7 @@ export const ObjectSearch = (props: ObjectSearchProps) => {
 
       if (updatedVisibleColumns) {
         setTableState((prev) => {
+          // When updating columns, include any non-ordered columns in the column order or reorder columns breaks (unless its currently empty/not set)
           const newColumnOrder =
             prev.columnOrder.length > 0
               ? [...new Set([...prev.columnOrder, ...sortedHeaders])]
@@ -280,7 +281,6 @@ export const ObjectSearch = (props: ObjectSearchProps) => {
           return {
             ...prev,
             columnVisibility: updatedVisibleColumns,
-            // When updating columns, always include any non-ordered columns in the column order or reorder columns breaks
             columnOrder: newColumnOrder,
           };
         });

--- a/src/components/objectSearch/objectSearch.component.tsx
+++ b/src/components/objectSearch/objectSearch.component.tsx
@@ -276,7 +276,7 @@ export const ObjectSearch = (props: ObjectSearchProps) => {
             prev.columnOrder.length > 0
               ? [...new Set([...prev.columnOrder, ...sortedHeaders])]
               : prev.columnOrder;
-          console.log({ prev, newColumnOrder, updatedVisibleColumns });
+
           return {
             ...prev,
             columnVisibility: updatedVisibleColumns,


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->

Previous PR introduced a bug because it always set the column order.

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Bugfix


