### PR TITLE
feat: Expand/focus single relationship

### DIFF
--- a/cypress/e2e/contentLibrary/panel/tabs/relationships.cy.ts
+++ b/cypress/e2e/contentLibrary/panel/tabs/relationships.cy.ts
@@ -27,12 +27,12 @@ describe("Content Library - Object Panel - Relationships Tab", () => {
 
     cy.contains("button", "Relationships").click();
 
-    cy.get("#relationship-panel-assets").scrollIntoView();
+    cy.get("#panel-section-assets").scrollIntoView();
 
-    cy.get("#relationship-panel-assets")
+    cy.get("#panel-section-assets")
       .parent()
       .within(() => {
-        cy.get("button").click();
+        cy.get('[aria-label="Open edit assets relationship modal"]').click();
       });
 
     cy.get("[data-testid=search-objects-modal-save]").should("exist");
@@ -43,7 +43,7 @@ describe("Content Library - Object Panel - Relationships Tab", () => {
 
     cy.get("[data-testid=search-objects-modal-save]").should("not.exist");
 
-    cy.get("#relationship-panel-assets").scrollIntoView();
+    cy.get("#panel-section-assets").scrollIntoView();
 
     cy.contains("GOT S04 Trailer");
 

--- a/src/components/panel/__tests__/tabs/relationships.test.tsx
+++ b/src/components/panel/__tests__/tabs/relationships.test.tsx
@@ -1,4 +1,3 @@
-import { prettyDOM } from "@testing-library/dom";
 import { graphql } from "msw";
 
 import GQLSkylarkGetSeasonWithRelationshipsQueryFixture from "src/__tests__/fixtures/skylark/queries/getObject/gots04.json";
@@ -42,7 +41,7 @@ describe("relationships view", () => {
       />,
     );
 
-    await waitFor(() => expect(screen.getAllByText("Episode")).toHaveLength(3));
+    await waitFor(() => expect(screen.getAllByText("Episode")).toHaveLength(5));
 
     expect(
       screen.getByTestId("expand-relationship-episodes"),
@@ -68,7 +67,7 @@ describe("relationships view", () => {
       />,
     );
 
-    await waitFor(() => expect(screen.getAllByText("Episode")).toHaveLength(3));
+    await waitFor(() => expect(screen.getAllByText("Episode")).toHaveLength(5));
 
     const withinEpisodesRelationship = within(screen.getByTestId("episodes"));
 
@@ -88,7 +87,7 @@ describe("relationships view", () => {
       />,
     );
 
-    await waitFor(() => expect(screen.getAllByText("Episode")).toHaveLength(3));
+    await waitFor(() => expect(screen.getAllByText("Episode")).toHaveLength(5));
 
     const withinFirstEpisodeCard = within(
       screen.getByTestId("panel-relationship-episodes-item-1"),
@@ -110,7 +109,7 @@ describe("relationships view", () => {
       />,
     );
 
-    await waitFor(() => expect(screen.getAllByText("Episode")).toHaveLength(3));
+    await waitFor(() => expect(screen.getAllByText("Episode")).toHaveLength(5));
 
     fireEvent.click(screen.getByText("Edit Relationships"));
 
@@ -130,7 +129,7 @@ describe("relationships view", () => {
       />,
     );
 
-    await waitFor(() => expect(screen.getAllByText("Episode")).toHaveLength(3));
+    await waitFor(() => expect(screen.getAllByText("Episode")).toHaveLength(5));
 
     const firstOpenObjectButton = screen.getAllByRole("button", {
       name: /Open Object/i,
@@ -144,7 +143,47 @@ describe("relationships view", () => {
     });
   });
 
-  test("calls updateActivePanelTabState with the selected relationship info as true when its expanded", async () => {
+  test("makes a relationship active and then closes it", async () => {
+    render(
+      <Panel
+        {...defaultProps}
+        object={seasonWithRelationships}
+        tab={PanelTab.Relationships}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getAllByText("Episode")).toHaveLength(5));
+    await waitFor(() =>
+      expect(screen.queryByText("Brands")).toBeInTheDocument(),
+    );
+
+    const withinEpisodesRelationship = within(screen.getByTestId("episodes"));
+
+    const expandButton = withinEpisodesRelationship.getByLabelText(
+      "expand episodes relationship",
+    );
+    fireEvent.click(expandButton);
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Episode")).toHaveLength(10),
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText("Brands")).not.toBeInTheDocument(),
+    );
+
+    const closeButton = withinEpisodesRelationship.getByLabelText(
+      "close episodes relationship",
+    );
+    fireEvent.click(closeButton);
+
+    await waitFor(() => expect(screen.getAllByText("Episode")).toHaveLength(5));
+    await waitFor(() =>
+      expect(screen.queryByText("Brands")).toBeInTheDocument(),
+    );
+  });
+
+  test("calls updateActivePanelTabState with the selected relationship info when it is made active", async () => {
     const updateActivePanelTabState = jest.fn();
     render(
       <Panel
@@ -155,7 +194,7 @@ describe("relationships view", () => {
       />,
     );
 
-    await waitFor(() => expect(screen.getAllByText("Episode")).toHaveLength(3));
+    await waitFor(() => expect(screen.getAllByText("Episode")).toHaveLength(5));
 
     const withinEpisodesRelationship = within(screen.getByTestId("episodes"));
 
@@ -168,9 +207,7 @@ describe("relationships view", () => {
 
     expect(updateActivePanelTabState).toHaveBeenCalledWith({
       Relationships: {
-        expanded: {
-          episodes: true,
-        },
+        active: "episodes",
       },
     });
   });
@@ -233,7 +270,7 @@ describe("relationships view", () => {
       />,
     );
 
-    await waitFor(() => expect(screen.getAllByText("Episode")).toHaveLength(3));
+    await waitFor(() => expect(screen.getAllByText("Episode")).toHaveLength(5));
 
     const withinEpisodesRelationship = within(screen.getByTestId("episodes"));
 
@@ -241,7 +278,18 @@ describe("relationships view", () => {
     fireEvent.click(showMoreButton);
 
     await waitFor(() =>
-      expect(screen.getByText("Episodes (20)")).toBeInTheDocument(),
+      expect(screen.getByText("Episodes")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Episodes").parentNode?.textContent).toBe(
+      "Episodes (10+)",
+    );
+
+    const loadMoreButton = withinEpisodesRelationship.getByText("Load more");
+    fireEvent.click(loadMoreButton);
+
+    await waitFor(() => expect(screen.getByText("(20)")).toBeInTheDocument());
+    expect(screen.getByText("Episodes").parentNode?.textContent).toBe(
+      "Episodes (20)",
     );
 
     expect(screen.getAllByText("Episode")).toHaveLength(20);
@@ -267,7 +315,7 @@ describe("relationships view", () => {
       );
 
       await waitFor(() =>
-        expect(screen.getAllByText("Episode")).toHaveLength(3),
+        expect(screen.getAllByText("Episode")).toHaveLength(5),
       );
 
       fireEvent.click(screen.getByText("Edit Relationships"));

--- a/src/components/panel/__tests__/utils/test-utils.ts
+++ b/src/components/panel/__tests__/utils/test-utils.ts
@@ -80,7 +80,7 @@ export const skylarkAssetObject: SkylarkObjectIdentifier = {
 
 const tabState: PanelTabState = {
   Relationships: {
-    expanded: {},
+    active: null,
   },
 };
 

--- a/src/components/panel/panel.stories.tsx
+++ b/src/components/panel/panel.stories.tsx
@@ -13,7 +13,7 @@ import { Panel } from "./panel.component";
 
 const defaultPanelTabState: PanelTabState = {
   [PanelTab.Relationships]: {
-    expanded: {},
+    active: null,
   },
 };
 

--- a/src/components/panel/panelSections/panelAvailability.component.tsx
+++ b/src/components/panel/panelSections/panelAvailability.component.tsx
@@ -15,7 +15,7 @@ import { PanelLoading } from "src/components/panel/panelLoading";
 import {
   PanelEmptyDataText,
   PanelFieldTitle,
-  PanelPlusButton,
+  PanelButton,
   PanelSectionTitle,
 } from "src/components/panel/panelTypography";
 import { Skeleton } from "src/components/skeleton";
@@ -277,7 +277,13 @@ export const PanelAvailability = (props: PanelAvailabilityProps) => {
 
   return (
     <PanelSectionLayout
-      sections={[{ id: "availability-panel-header", title: "Availability" }]}
+      sections={[
+        {
+          id: "availability",
+          htmlId: "availability-panel-header",
+          title: "Availability",
+        },
+      ]}
       isPage={isPage}
     >
       <div data-testid="panel-availability">
@@ -286,7 +292,10 @@ export const PanelAvailability = (props: PanelAvailabilityProps) => {
             text={formatObjectField("Availability")}
             id={"availability-panel-header"}
           />
-          <PanelPlusButton onClick={() => setObjectSearchModalOpen(true)} />
+          <PanelButton
+            type="plus"
+            onClick={() => setObjectSearchModalOpen(true)}
+          />
         </div>
         {data && (
           <>

--- a/src/components/panel/panelSections/panelAvailabilityDimensions.component.tsx
+++ b/src/components/panel/panelSections/panelAvailabilityDimensions.component.tsx
@@ -89,7 +89,8 @@ export const PanelAvailabilityDimensions = ({
   return (
     <PanelSectionLayout
       sections={(dimensions || []).map(({ uid, title, slug }) => ({
-        id: `dimensions-panel-${uid}`,
+        htmlId: `dimensions-panel-${uid}`,
+        id: uid,
         title: formatObjectField(title || slug),
       }))}
       isPage={isPage}

--- a/src/components/panel/panelSections/panelContent.component.tsx
+++ b/src/components/panel/panelSections/panelContent.component.tsx
@@ -167,7 +167,9 @@ export const PanelContent = ({
 
   return (
     <PanelSectionLayout
-      sections={[{ id: "content-panel-title", title: "Content" }]}
+      sections={[
+        { htmlId: "content-panel-title", title: "Content", id: "content" },
+      ]}
       isPage={isPage}
     >
       <PanelSectionTitle

--- a/src/components/panel/panelSections/panelContentOf.component.tsx
+++ b/src/components/panel/panelSections/panelContentOf.component.tsx
@@ -73,10 +73,11 @@ export const PanelContentOf = ({
           ?.map(({ objectType, config }) => {
             return {
               objectType,
-              id: `content-of-panel-${objectType}`,
+              htmlId: `content-of-panel-${objectType}`,
               title: formatObjectField(
                 config?.objectTypeDisplayName || objectType,
               ),
+              id: objectType,
               objects: objectTypeGroupedData[objectType],
             };
           })

--- a/src/components/panel/panelSections/panelImages.component.tsx
+++ b/src/components/panel/panelSections/panelImages.component.tsx
@@ -122,7 +122,8 @@ export const PanelImages = ({
   return (
     <PanelSectionLayout
       sections={images.map(({ name }) => ({
-        id: `image-panel-${name}`,
+        id: name,
+        htmlId: `image-panel-${name}`,
         title: formatObjectField(name),
       }))}
       isPage={isPage}

--- a/src/components/panel/panelSections/panelMetadata.component.tsx
+++ b/src/components/panel/panelSections/panelMetadata.component.tsx
@@ -92,7 +92,11 @@ export const PanelMetadata = ({
     },
   ].filter(({ metadataFields }) => metadataFields.length > 0);
 
-  const sideBarSections = sections.map(({ id, title }) => ({ id, title }));
+  const sideBarSections = sections.map(({ id, title }) => ({
+    id,
+    title,
+    htmlId: id,
+  }));
 
   return (
     <PanelSectionLayout sections={sideBarSections} isPage={isPage}>

--- a/src/components/panel/panelSections/panelMetadata.component.tsx
+++ b/src/components/panel/panelSections/panelMetadata.component.tsx
@@ -76,26 +76,29 @@ export const PanelMetadata = ({
 
   const sections = [
     {
-      id: "system",
+      id: "system-metadata",
       title: "System Metadata",
+      htmlId: "panel-section-system",
       metadataFields: systemMetadataFields,
     },
     {
-      id: "translatable",
+      id: "translatable-metadata",
       title: "Translatable Metadata",
+      htmlId: "panel-section-translatable",
       metadataFields: translatableMetadataFields,
     },
     {
-      id: "global",
+      id: "global-metadata",
       title: "Global Metadata",
+      htmlId: "panel-section-global",
       metadataFields: globalMetadataFields,
     },
   ].filter(({ metadataFields }) => metadataFields.length > 0);
 
-  const sideBarSections = sections.map(({ id, title }) => ({
+  const sideBarSections = sections.map(({ id, title, htmlId }) => ({
     id,
     title,
-    htmlId: id,
+    htmlId,
   }));
 
   return (
@@ -113,9 +116,13 @@ export const PanelMetadata = ({
         onSubmit={(e) => e.preventDefault()}
       >
         {sections.map(
-          ({ id, title, metadataFields }, index, { length: numSections }) => (
+          (
+            { id, title, metadataFields, htmlId },
+            index,
+            { length: numSections },
+          ) => (
             <div key={id} className="mb-8 md:mb-10">
-              <PanelSectionTitle id={id} text={title} />
+              <PanelSectionTitle id={htmlId} text={title} />
               {metadataFields.map(({ field, config }) => {
                 const fieldConfigFromObject = objectFieldConfigArr?.find(
                   ({ name }) => name === field,

--- a/src/components/panel/panelSections/panelPlayback.component.tsx
+++ b/src/components/panel/panelSections/panelPlayback.component.tsx
@@ -42,6 +42,7 @@ const getVideoTypeSections = (
 ): {
   type: string;
   id: string;
+  htmlId: string;
   title: string;
   properties: {
     key: string;
@@ -60,7 +61,8 @@ const getVideoTypeSections = (
             : "";
         return {
           type: videoType,
-          id: `playback-panel-external`,
+          htmlId: `playback-panel-external`,
+          id: videoType,
           title: videoType.toUpperCase(),
           properties: url
             ? [{ key: "url", property: "URL", isUrl: true, value: url }]
@@ -86,7 +88,8 @@ const getVideoTypeSections = (
 
       return {
         type: videoType,
-        id: `playback-panel-${videoType}`,
+        id: videoType,
+        htmlId: `playback-panel-${videoType}`,
         title: videoType.toUpperCase(),
         properties,
         url: hasProperty(metadata, urlKey) && metadata[urlKey],
@@ -173,7 +176,8 @@ const RelationshipPlayback = ({
   const sections = [...assetRelationships, ...liveAssetRelationships]
     .sort((a, b) => (a.objects.length > b.objects.length ? -1 : 1))
     .map(({ objects, name }) => ({
-      id: `playback-panel-${name}`,
+      id: name,
+      htmlId: `playback-panel-${name}`,
       title: formatObjectField(name),
       relationshipName: name,
       objects: objects,

--- a/src/components/panel/panelSections/panelRelationshipsSection.component.tsx
+++ b/src/components/panel/panelSections/panelRelationshipsSection.component.tsx
@@ -53,7 +53,6 @@ const PanelRelationshipSectionComponent = (
     inEditMode,
     isFetchingMoreRelationships,
     newUids,
-    // variant,
     isExpanded,
     config,
     hasMoreRelationships,
@@ -238,7 +237,6 @@ const PanelRelationshipSectionComponent = (
               {canLoadMore
                 ? "Load more"
                 : `Show ${isExpanded ? "less" : "more"}`}
-              {/* {isExpanded ? "Collapse" : "Expand"} */}
             </button>
           </>
         )}

--- a/src/components/panel/panelSections/panelRelationshipsSection.component.tsx
+++ b/src/components/panel/panelSections/panelRelationshipsSection.component.tsx
@@ -131,6 +131,7 @@ const PanelRelationshipSectionComponent = (
           />
           {!isFetchingMoreRelationships && (
             <PanelButton
+              aria-label={`Open edit ${relationshipName} relationship modal`}
               className="ml-1"
               type="plus"
               onClick={() =>

--- a/src/components/panel/panelSections/panelRelationshipsSection.component.tsx
+++ b/src/components/panel/panelSections/panelRelationshipsSection.component.tsx
@@ -95,21 +95,22 @@ export const PanelRelationshipSection = ({
 
   return (
     <m.div
-      layout
-      className={clsx(
-        "pb-6 bg-white",
-        // isExpanded ? "absolute z-10 left-0 right-0" : "relative",
-      )}
+      key={`${relationshipName}-container`}
+      // layout
+      className={clsx("pb-6 bg-white")}
       data-testid={relationshipName}
       transition={{ duration: 0.08 }}
       initial={{ opacity: 0, height: "auto" }}
       animate={{ opacity: 1, height: "auto" }}
       exit={{ opacity: 0, height: "auto" }}
     >
-      <div
+      <m.div
+        key={`${relationshipName}-title`}
+        layout
         className={clsx(
           "flex items-center justify-between bg-white pt-8 -mt-8",
           isExpanded && "sticky top-0 z-10",
+          !isExpanded && "relative z-10",
         )}
       >
         <div className="flex items-center -ml-7">
@@ -146,10 +147,19 @@ export const PanelRelationshipSection = ({
             config.defaultSortField,
           )}`}</p>
         )}
-      </div>
+      </m.div>
 
-      <m.div className="" layout="position">
-        <AnimatePresence mode="sync" initial={false}>
+      <m.div
+        key={`${relationshipName}-objects`}
+        className={
+          clsx()
+          // "grid grid-rows-[1fr] transition-grid-template-rows",
+          // isExpanded && "absolute",
+        }
+        layout="position"
+      >
+        <div className="overflow-hidden">
+          {/* <AnimatePresence mode="sync" initial={false}> */}
           {displayList?.length > 0 &&
             displayList?.map((obj, index) => {
               const defaultSortFieldValue =
@@ -160,16 +170,18 @@ export const PanelRelationshipSection = ({
               return (
                 <m.div
                   key={`relationship-${obj.objectType}-${obj.uid}`}
-                  initial={{ opacity: 0, height: 0 }}
+                  // layout
+                  initial={{ opacity: 0, height: "auto" }}
                   animate={{ opacity: 1, height: "auto" }}
-                  exit={{ opacity: 0, height: 0 }}
+                  exit={{ opacity: 0, height: "auto" }}
                   transition={{
                     height: { duration: 0.15 },
                     opacity: { duration: 0.06 },
+                    ease: "linear",
                   }}
                 >
                   <div
-                    className="flex items-center"
+                    className="flex items-center bg-white"
                     data-testid={`panel-relationship-${relationshipName}-item-${
                       index + 1
                     }`}
@@ -216,18 +228,17 @@ export const PanelRelationshipSection = ({
                 </m.div>
               );
             })}
-        </AnimatePresence>
+          {/* </AnimatePresence> */}
+        </div>
       </m.div>
 
       {/* {variant === "minimal" && relationship && objects.length > 3 && ( */}
-      <div
-        className="mb-3"
-        ref={isExpanded && hasMoreRelationships ? ref : null}
-      >
+      <m.div layout className="mb-3">
         {hasShowMore && toggleExpanded && (
           <>
             <PanelSeparator />
             <button
+              ref={isExpanded && hasMoreRelationships ? ref : null}
               data-testid={`expand-relationship-${relationshipName}`}
               onClick={toggleExpanded}
               className="w-full cursor-pointer p-2 text-center text-xs text-manatee-500 hover:text-manatee-700"
@@ -237,7 +248,7 @@ export const PanelRelationshipSection = ({
             </button>
           </>
         )}
-      </div>
+      </m.div>
       {/* )} */}
     </m.div>
   );

--- a/src/components/panel/panelSections/panelRelationshipsSection.component.tsx
+++ b/src/components/panel/panelSections/panelRelationshipsSection.component.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
-import { AnimatePresence, m } from "framer-motion";
-import { useState, Fragment, useEffect } from "react";
+import { Transition, m } from "framer-motion";
+import { Fragment, Ref, forwardRef, useEffect } from "react";
 import { useInView } from "react-intersection-observer";
 import { sentenceCase } from "sentence-case";
 
@@ -11,7 +11,6 @@ import {
   PanelSeparator,
 } from "src/components/panel/panelTypography";
 import { Tooltip } from "src/components/tooltip/tooltip.component";
-import { PanelTab, PanelTabState } from "src/hooks/state";
 import { useSkylarkObjectOperations } from "src/hooks/useSkylarkObjectTypes";
 import {
   ParsedSkylarkObjectRelationship,
@@ -26,7 +25,6 @@ interface PanelRelationshipsSectionProps {
   inEditMode: boolean;
   isFetchingMoreRelationships: boolean;
   newUids: string[];
-  // variant: "minimal" | "full";
   isExpanded: boolean;
   config: ParsedSkylarkObjectTypeRelationshipConfiguration["config"] | null;
   setExpandedRelationship: (r: string | null) => void;
@@ -39,41 +37,37 @@ interface PanelRelationshipsSectionProps {
     relationship: ParsedSkylarkObjectRelationship;
     fields?: string[];
   }) => void;
-  updateActivePanelTabState: (s: Partial<PanelTabState>) => void;
   hasMoreRelationships?: boolean;
   fetchMoreRelationships: () => void;
 }
 
-export const PanelRelationshipSection = ({
-  isEmptySection,
-  relationship,
-  inEditMode,
-  isFetchingMoreRelationships,
-  newUids,
-  // variant,
-  isExpanded,
-  config,
-  hasMoreRelationships,
-  setPanelObject,
-  removeRelationshipObject,
-  setSearchObjectsModalState,
-  setExpandedRelationship,
-  fetchMoreRelationships,
-}: PanelRelationshipsSectionProps) => {
+const transition: Transition = {
+  duration: 0.15,
+  ease: "linear",
+};
+
+const PanelRelationshipSectionComponent = (
+  {
+    isEmptySection,
+    relationship,
+    inEditMode,
+    isFetchingMoreRelationships,
+    newUids,
+    // variant,
+    isExpanded,
+    config,
+    hasMoreRelationships,
+    setPanelObject,
+    removeRelationshipObject,
+    setSearchObjectsModalState,
+    setExpandedRelationship,
+    fetchMoreRelationships,
+  }: PanelRelationshipsSectionProps,
+  ref: Ref<HTMLDivElement>,
+) => {
   const { name: relationshipName, objects, objectType } = relationship;
 
-  // const [isExpanded, setIsExpanded] = useState(initialExpanded);
-
-  // const toggleExpanded = () => {
-  //   updateActivePanelTabState({
-  //     [PanelTab.Relationships]: {
-  //       expanded: { [relationshipName]: !isExpanded },
-  //     },
-  //   });
-  //   setIsExpanded(!isExpanded);
-  // };
-
-  const { ref, inView } = useInView();
+  const { ref: inViewRef, inView } = useInView();
 
   useEffect(() => {
     if (inView && hasMoreRelationships) {
@@ -93,13 +87,15 @@ export const PanelRelationshipSection = ({
     setExpandedRelationship(isExpanded ? null : relationshipName);
   };
 
+  const canLoadMore = isExpanded && hasMoreRelationships;
+
   return (
     <m.div
+      ref={ref}
       key={`${relationshipName}-container`}
-      // layout
       className={clsx("pb-6 bg-white")}
       data-testid={relationshipName}
-      transition={{ duration: 0.08 }}
+      transition={transition}
       initial={{ opacity: 0, height: "auto" }}
       animate={{ opacity: 1, height: "auto" }}
       exit={{ opacity: 0, height: "auto" }}
@@ -107,6 +103,7 @@ export const PanelRelationshipSection = ({
       <m.div
         key={`${relationshipName}-title`}
         layout
+        transition={transition}
         className={clsx(
           "flex items-center justify-between bg-white pt-8 -mt-8",
           isExpanded && "sticky top-0 z-10",
@@ -116,6 +113,9 @@ export const PanelRelationshipSection = ({
         <div className="flex items-center -ml-7">
           {toggleExpanded && (
             <PanelButton
+              aria-label={`${
+                isExpanded ? "close" : "expand"
+              } ${relationshipName} relationship`}
               className="mx-0.5"
               type={isExpanded ? "x" : "maximise"}
               onClick={toggleExpanded}
@@ -151,15 +151,10 @@ export const PanelRelationshipSection = ({
 
       <m.div
         key={`${relationshipName}-objects`}
-        className={
-          clsx()
-          // "grid grid-rows-[1fr] transition-grid-template-rows",
-          // isExpanded && "absolute",
-        }
+        transition={transition}
         layout="position"
       >
         <div className="overflow-hidden">
-          {/* <AnimatePresence mode="sync" initial={false}> */}
           {displayList?.length > 0 &&
             displayList?.map((obj, index) => {
               const defaultSortFieldValue =
@@ -170,13 +165,11 @@ export const PanelRelationshipSection = ({
               return (
                 <m.div
                   key={`relationship-${obj.objectType}-${obj.uid}`}
-                  // layout
-                  initial={{ opacity: 0, height: "auto" }}
-                  animate={{ opacity: 1, height: "auto" }}
-                  exit={{ opacity: 0, height: "auto" }}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
                   transition={{
-                    height: { duration: 0.15 },
-                    opacity: { duration: 0.06 },
+                    duration: 0.05,
                     ease: "linear",
                   }}
                 >
@@ -228,28 +221,31 @@ export const PanelRelationshipSection = ({
                 </m.div>
               );
             })}
-          {/* </AnimatePresence> */}
         </div>
       </m.div>
 
-      {/* {variant === "minimal" && relationship && objects.length > 3 && ( */}
-      <m.div layout className="mb-3">
+      <m.div layout className="mb-3" transition={{ duration: 0.08 }}>
         {hasShowMore && toggleExpanded && (
           <>
             <PanelSeparator />
             <button
-              ref={isExpanded && hasMoreRelationships ? ref : null}
+              ref={canLoadMore ? inViewRef : null}
               data-testid={`expand-relationship-${relationshipName}`}
-              onClick={toggleExpanded}
+              onClick={canLoadMore ? fetchMoreRelationships : toggleExpanded}
               className="w-full cursor-pointer p-2 text-center text-xs text-manatee-500 hover:text-manatee-700"
             >
-              {`Show ${isExpanded ? "less" : "more"}`}
+              {canLoadMore
+                ? "Load more"
+                : `Show ${isExpanded ? "less" : "more"}`}
               {/* {isExpanded ? "Collapse" : "Expand"} */}
             </button>
           </>
         )}
       </m.div>
-      {/* )} */}
     </m.div>
   );
 };
+
+export const PanelRelationshipSection = forwardRef(
+  PanelRelationshipSectionComponent,
+);

--- a/src/components/panel/panelSections/panelRelationshipsSection.component.tsx
+++ b/src/components/panel/panelSections/panelRelationshipsSection.component.tsx
@@ -1,9 +1,12 @@
-import { useState, Fragment } from "react";
+import clsx from "clsx";
+import { AnimatePresence, m } from "framer-motion";
+import { useState, Fragment, useEffect } from "react";
+import { useInView } from "react-intersection-observer";
 import { sentenceCase } from "sentence-case";
 
 import { ObjectIdentifierCard } from "src/components/objectIdentifierCard";
 import {
-  PanelPlusButton,
+  PanelButton,
   PanelSectionTitle,
   PanelSeparator,
 } from "src/components/panel/panelTypography";
@@ -23,8 +26,10 @@ interface PanelRelationshipsSectionProps {
   inEditMode: boolean;
   isFetchingMoreRelationships: boolean;
   newUids: string[];
-  initialExpanded: boolean;
+  // variant: "minimal" | "full";
+  isExpanded: boolean;
   config: ParsedSkylarkObjectTypeRelationshipConfiguration["config"] | null;
+  setExpandedRelationship: (r: string | null) => void;
   setPanelObject: (o: SkylarkObjectIdentifier) => void;
   removeRelationshipObject: (args: {
     uid: string;
@@ -35,6 +40,8 @@ interface PanelRelationshipsSectionProps {
     fields?: string[];
   }) => void;
   updateActivePanelTabState: (s: Partial<PanelTabState>) => void;
+  hasMoreRelationships?: boolean;
+  fetchMoreRelationships: () => void;
 }
 
 export const PanelRelationshipSection = ({
@@ -43,48 +50,88 @@ export const PanelRelationshipSection = ({
   inEditMode,
   isFetchingMoreRelationships,
   newUids,
-  initialExpanded,
+  // variant,
+  isExpanded,
   config,
+  hasMoreRelationships,
   setPanelObject,
   removeRelationshipObject,
   setSearchObjectsModalState,
-  updateActivePanelTabState,
+  setExpandedRelationship,
+  fetchMoreRelationships,
 }: PanelRelationshipsSectionProps) => {
   const { name: relationshipName, objects, objectType } = relationship;
 
-  const [isExpanded, setIsExpanded] = useState(initialExpanded);
+  // const [isExpanded, setIsExpanded] = useState(initialExpanded);
 
-  const toggleExpanded = () => {
-    updateActivePanelTabState({
-      [PanelTab.Relationships]: {
-        expanded: { [relationshipName]: !isExpanded },
-      },
-    });
-    setIsExpanded(!isExpanded);
-  };
+  // const toggleExpanded = () => {
+  //   updateActivePanelTabState({
+  //     [PanelTab.Relationships]: {
+  //       expanded: { [relationshipName]: !isExpanded },
+  //     },
+  //   });
+  //   setIsExpanded(!isExpanded);
+  // };
+
+  const { ref, inView } = useInView();
+
+  useEffect(() => {
+    if (inView && hasMoreRelationships) {
+      fetchMoreRelationships();
+    }
+  });
 
   const { objectOperations } = useSkylarkObjectOperations(objectType);
   const objectFields = objectOperations?.fields.map(({ name }) => name);
 
+  const hasShowMore = objects?.length > 4;
+
   const displayList =
-    objects?.length > 2 && !isExpanded ? objects.slice(0, 3) : objects;
+    hasShowMore && !isExpanded ? objects.slice(0, 5) : objects;
+
+  const toggleExpanded = () => {
+    setExpandedRelationship(isExpanded ? null : relationshipName);
+  };
 
   return (
-    <div
-      key={relationshipName}
-      className="relative mb-6"
+    <m.div
+      layout
+      className={clsx(
+        "pb-6 bg-white",
+        // isExpanded ? "absolute z-10 left-0 right-0" : "relative",
+      )}
       data-testid={relationshipName}
+      transition={{ duration: 0.08 }}
+      initial={{ opacity: 0, height: "auto" }}
+      animate={{ opacity: 1, height: "auto" }}
+      exit={{ opacity: 0, height: "auto" }}
     >
-      <div className="flex items-center justify-between">
-        <div className="flex items-center">
+      <div
+        className={clsx(
+          "flex items-center justify-between bg-white pt-8 -mt-8",
+          isExpanded && "sticky top-0 z-10",
+        )}
+      >
+        <div className="flex items-center -ml-7">
+          {toggleExpanded && (
+            <PanelButton
+              className="mx-0.5"
+              type={isExpanded ? "x" : "maximise"}
+              onClick={toggleExpanded}
+            />
+          )}
           <PanelSectionTitle
             text={formatObjectField(relationshipName)}
-            count={objects.length || 0}
-            id={`relationship-panel-${relationshipName}`}
+            count={
+              hasMoreRelationships ? `${objects.length}+` : objects.length || 0
+            }
+            id={`panel-section-${relationshipName}`}
             loading={isFetchingMoreRelationships}
           />
           {!isFetchingMoreRelationships && (
-            <PanelPlusButton
+            <PanelButton
+              className="ml-1"
+              type="plus"
               onClick={() =>
                 setSearchObjectsModalState({
                   relationship,
@@ -101,81 +148,97 @@ export const PanelRelationshipSection = ({
         )}
       </div>
 
-      <div className="transition duration-300 ease-in-out">
-        {displayList?.length > 0 ? (
-          displayList?.map((obj, index) => {
-            const defaultSortFieldValue =
-              config?.defaultSortField &&
-              hasProperty(obj.metadata, config.defaultSortField) &&
-              obj.metadata[config.defaultSortField];
+      <m.div className="" layout="position">
+        <AnimatePresence mode="sync" initial={false}>
+          {displayList?.length > 0 &&
+            displayList?.map((obj, index) => {
+              const defaultSortFieldValue =
+                config?.defaultSortField &&
+                hasProperty(obj.metadata, config.defaultSortField) &&
+                obj.metadata[config.defaultSortField];
 
-            return (
-              <Fragment key={`relationship-${obj.objectType}-${obj.uid}`}>
-                <div
-                  className="flex items-center"
-                  data-testid={`panel-relationship-${relationshipName}-item-${
-                    index + 1
-                  }`}
+              return (
+                <m.div
+                  key={`relationship-${obj.objectType}-${obj.uid}`}
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: "auto" }}
+                  exit={{ opacity: 0, height: 0 }}
+                  transition={{
+                    height: { duration: 0.15 },
+                    opacity: { duration: 0.06 },
+                  }}
                 >
-                  <ObjectIdentifierCard
-                    object={obj}
-                    disableDeleteClick={!inEditMode}
-                    disableForwardClick={inEditMode}
-                    onDeleteClick={() =>
-                      removeRelationshipObject({
-                        uid: obj.uid,
-                        relationshipName,
-                      })
-                    }
-                    onForwardClick={setPanelObject}
+                  <div
+                    className="flex items-center"
+                    data-testid={`panel-relationship-${relationshipName}-item-${
+                      index + 1
+                    }`}
                   >
-                    {config?.defaultSortField && (
-                      <Tooltip
-                        tooltip={`${sentenceCase(
-                          config.defaultSortField,
-                        )}: ${defaultSortFieldValue}`}
-                      >
-                        <p
-                          className="flex max-w-8 min-w-3 overflow-hidden whitespace-nowrap text-sm text-manatee-500 cursor-default"
-                          data-testid="object-sort-field"
+                    <ObjectIdentifierCard
+                      object={obj}
+                      disableDeleteClick={!inEditMode}
+                      disableForwardClick={inEditMode}
+                      onDeleteClick={() =>
+                        removeRelationshipObject({
+                          uid: obj.uid,
+                          relationshipName,
+                        })
+                      }
+                      onForwardClick={setPanelObject}
+                    >
+                      {config?.defaultSortField && (
+                        <Tooltip
+                          tooltip={`${sentenceCase(
+                            config.defaultSortField,
+                          )}: ${defaultSortFieldValue}`}
                         >
-                          <span className="overflow-hidden text-ellipsis">
-                            {defaultSortFieldValue}
-                          </span>
-                        </p>
-                      </Tooltip>
-                    )}
-                    {inEditMode && newUids?.includes(obj.uid) && (
-                      <span
-                        className={
-                          "flex h-4 w-4 items-center justify-center rounded-full bg-success px-1 pb-0.5 text-center text-white transition-colors"
-                        }
-                      />
-                    )}
-                  </ObjectIdentifierCard>
-                </div>
+                          <p
+                            className="flex max-w-8 min-w-3 overflow-hidden whitespace-nowrap text-sm text-manatee-500 cursor-default"
+                            data-testid="object-sort-field"
+                          >
+                            <span className="overflow-hidden text-ellipsis">
+                              {defaultSortFieldValue}
+                            </span>
+                          </p>
+                        </Tooltip>
+                      )}
+                      {inEditMode && newUids?.includes(obj.uid) && (
+                        <span
+                          className={
+                            "flex h-4 w-4 items-center justify-center rounded-full bg-success px-1 pb-0.5 text-center text-white transition-colors"
+                          }
+                        />
+                      )}
+                    </ObjectIdentifierCard>
+                  </div>
 
-                {index < displayList.length - 1 && <PanelSeparator />}
-              </Fragment>
-            );
-          })
-        ) : (
-          <></>
+                  {index < displayList.length - 1 && <PanelSeparator />}
+                </m.div>
+              );
+            })}
+        </AnimatePresence>
+      </m.div>
+
+      {/* {variant === "minimal" && relationship && objects.length > 3 && ( */}
+      <div
+        className="mb-3"
+        ref={isExpanded && hasMoreRelationships ? ref : null}
+      >
+        {hasShowMore && toggleExpanded && (
+          <>
+            <PanelSeparator />
+            <button
+              data-testid={`expand-relationship-${relationshipName}`}
+              onClick={toggleExpanded}
+              className="w-full cursor-pointer p-2 text-center text-xs text-manatee-500 hover:text-manatee-700"
+            >
+              {`Show ${isExpanded ? "less" : "more"}`}
+              {/* {isExpanded ? "Collapse" : "Expand"} */}
+            </button>
+          </>
         )}
       </div>
-
-      {relationship && objects.length > 3 && (
-        <div className="mb-3">
-          <PanelSeparator />
-          <button
-            data-testid={`expand-relationship-${relationshipName}`}
-            onClick={toggleExpanded}
-            className="w-full cursor-pointer p-2 text-center text-xs text-manatee-500 hover:text-manatee-700"
-          >
-            {`Show ${isExpanded ? "less" : "more"}`}
-          </button>
-        </div>
-      )}
-    </div>
+      {/* )} */}
+    </m.div>
   );
 };

--- a/src/components/panel/panelSections/panelSectionLayout.component.tsx
+++ b/src/components/panel/panelSections/panelSectionLayout.component.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { ReactNode } from "react";
+import { ReactNode, Ref, forwardRef } from "react";
 
 import { hasProperty } from "src/lib/utils";
 
@@ -26,13 +26,16 @@ const scrollToSection = (id: string) =>
         : "smooth",
   });
 
-export const PanelSectionLayout = ({
-  isPage,
-  sections,
-  withStickyHeaders,
-  children,
-  onSectionClick,
-}: PanelSectionLayoutProps) => (
+export const PanelSectionLayoutComponent = (
+  {
+    isPage,
+    sections,
+    withStickyHeaders,
+    children,
+    onSectionClick,
+  }: PanelSectionLayoutProps,
+  ref: Ref<HTMLDivElement>,
+) => (
   <div
     className={clsx(
       "mx-auto w-full max-w-7xl flex-grow overflow-y-hidden text-sm ",
@@ -59,7 +62,7 @@ export const PanelSectionLayout = ({
         ))}
       </div>
     )}
-    <div className="h-full overflow-y-auto">
+    <div className="h-full overflow-y-auto" ref={ref}>
       <div
         className={clsx(
           "relative pb-32 md:pb-56",
@@ -71,3 +74,5 @@ export const PanelSectionLayout = ({
     </div>
   </div>
 );
+
+export const PanelSectionLayout = forwardRef(PanelSectionLayoutComponent);

--- a/src/components/panel/panelSections/panelSectionLayout.component.tsx
+++ b/src/components/panel/panelSections/panelSectionLayout.component.tsx
@@ -3,19 +3,23 @@ import { ReactNode } from "react";
 
 import { hasProperty } from "src/lib/utils";
 
+type Section = {
+  title: string;
+  id: string;
+  htmlId: string;
+};
+
 interface PanelSectionLayoutProps {
   isPage?: boolean;
-  sections: {
-    title: string;
-    id: string;
-  }[];
+  sections: Section[];
   withStickyHeaders?: boolean;
   children?: ReactNode;
+  onSectionClick?: (s: Section) => void;
 }
 
 const scrollToSection = (id: string) =>
   // Smooth scrolling breaks Cypress tests, we might want to refactor this to be global if we add another smooth scroll
-  document?.getElementById(id)?.scrollIntoView({
+  document?.getElementById(`panel-section-${id}`)?.scrollIntoView({
     behavior:
       typeof window === "undefined" || hasProperty(window, "Cypress")
         ? "auto"
@@ -27,6 +31,7 @@ export const PanelSectionLayout = ({
   sections,
   withStickyHeaders,
   children,
+  onSectionClick,
 }: PanelSectionLayoutProps) => (
   <div
     className={clsx(
@@ -39,13 +44,17 @@ export const PanelSectionLayout = ({
         className="pointer hidden flex-col p-4 text-left text-sm font-semibold sm:flex md:p-8"
         data-testid="panel-page-side-navigation"
       >
-        {sections.map(({ id, title }) => (
+        {sections.map((section) => (
           <button
-            key={`panel-section-scroll-button-${id}`}
-            onClick={() => scrollToSection(id)}
+            key={`panel-section-scroll-button-${section.id}`}
+            onClick={() =>
+              onSectionClick
+                ? onSectionClick(section)
+                : scrollToSection(section.htmlId || section.id)
+            }
             className="py-3 text-left text-manatee-700 transition-colors hover:text-black"
           >
-            {title}
+            {section.title}
           </button>
         ))}
       </div>

--- a/src/components/panel/panelSections/panelSectionLayout.component.tsx
+++ b/src/components/panel/panelSections/panelSectionLayout.component.tsx
@@ -19,7 +19,10 @@ interface PanelSectionLayoutProps {
 
 const scrollToSection = (id: string) =>
   // Smooth scrolling breaks Cypress tests, we might want to refactor this to be global if we add another smooth scroll
-  document?.getElementById(`panel-section-${id}`)?.scrollIntoView({
+  (
+    document?.getElementById(`panel-section-${id}`) ||
+    document?.getElementById(id)
+  )?.scrollIntoView({
     behavior:
       typeof window === "undefined" || hasProperty(window, "Cypress")
         ? "auto"

--- a/src/components/panel/panelTypography/panelTypography.component.tsx
+++ b/src/components/panel/panelTypography/panelTypography.component.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+import { Ref, forwardRef } from "react";
 import { CgSpinner } from "react-icons/cg";
 import {
   FiBookOpen,
@@ -72,14 +73,18 @@ export const PanelEmptyDataText = () => (
   <p className="text-sm text-manatee-500">None</p>
 );
 
-export const PanelSeparator = ({
-  transparent,
-  className,
-}: {
-  transparent?: boolean;
-  className?: string;
-}) => (
+export const PanelSeparatorComponent = (
+  {
+    transparent,
+    className,
+  }: {
+    transparent?: boolean;
+    className?: string;
+  },
+  ref: Ref<HTMLSpanElement>,
+) => (
   <span
+    ref={ref}
     className={clsx(
       "flex h-px w-full flex-grow",
       transparent ? "bg-transparent" : "bg-manatee-100",
@@ -87,17 +92,20 @@ export const PanelSeparator = ({
     )}
   />
 );
+export const PanelSeparator = forwardRef(PanelSeparatorComponent);
 
 export const PanelButton = ({
   onClick,
   type,
   className,
+  ...props
 }: {
   onClick: () => void;
   type: "plus" | "maximise" | "minimise" | "x";
   className?: string;
 }) => (
   <button
+    {...props}
     className={clsx(
       "mb-4 px-1 py-1 text-manatee-500 transition-colors hover:text-brand-primary",
       className,

--- a/src/components/panel/panelTypography/panelTypography.component.tsx
+++ b/src/components/panel/panelTypography/panelTypography.component.tsx
@@ -1,6 +1,12 @@
 import clsx from "clsx";
 import { CgSpinner } from "react-icons/cg";
-import { FiPlus } from "react-icons/fi";
+import {
+  FiBookOpen,
+  FiMaximize2,
+  FiMinimize2,
+  FiPlus,
+  FiX,
+} from "react-icons/fi";
 
 import { CopyToClipboard } from "src/components/copyToClipboard/copyToClipboard.component";
 
@@ -24,11 +30,12 @@ export const PanelSectionTitle = ({
     <h3
       id={id}
       className={clsx(
-        "bg-white text-base font-semibold underline inline-block",
+        "bg-white text-base font-semibold inline-block",
         sticky ? "sticky top-0 z-[2] pb-2 pt-4 md:pt-8" : "mb-2 pb-1 md:pb-2",
       )}
     >
-      {count !== undefined && !loading ? `${text} (${count})` : text}
+      <span className="underline">{text}</span>
+      {count !== undefined && !loading && ` (${count})`}
       {loading && (
         <CgSpinner className="inline-block ml-2 animate-spin h-4 w-4 mb-0.5" />
       )}
@@ -81,11 +88,25 @@ export const PanelSeparator = ({
   />
 );
 
-export const PanelPlusButton = ({ onClick }: { onClick: () => void }) => (
+export const PanelButton = ({
+  onClick,
+  type,
+  className,
+}: {
+  onClick: () => void;
+  type: "plus" | "maximise" | "minimise" | "x";
+  className?: string;
+}) => (
   <button
-    className="mb-4 px-2 py-1 text-manatee-500 transition-colors hover:text-brand-primary"
+    className={clsx(
+      "mb-4 px-1 py-1 text-manatee-500 transition-colors hover:text-brand-primary",
+      className,
+    )}
     onClick={onClick}
   >
-    <FiPlus className="h-4 w-4" />
+    {type === "plus" && <FiPlus className="h-4 w-4" />}
+    {type === "maximise" && <FiMaximize2 className="h-4 w-4" />}
+    {type === "minimise" && <FiMinimize2 className="h-4 w-4" />}
+    {type === "x" && <FiX className="h-4 w-4" />}
   </button>
 );

--- a/src/hooks/objects/get/useGetObjectRelationships.ts
+++ b/src/hooks/objects/get/useGetObjectRelationships.ts
@@ -131,10 +131,6 @@ export const useGetObjectRelationships = (
       enabled: query !== null,
     });
 
-  // if (hasNextPage) {
-  //   fetchNextPage();
-  // }
-
   const relationships: ParsedSkylarkObjectRelationships | null = useMemo(() => {
     if (!data?.pages || data.pages.length === 0) {
       return null;

--- a/src/hooks/objects/get/useGetObjectRelationships.ts
+++ b/src/hooks/objects/get/useGetObjectRelationships.ts
@@ -176,8 +176,6 @@ export const useGetObjectRelationships = (
     ? getRelationshipNextTokens(data.pages[data.pages.length - 1])
     : { relationshipsWithNextPage: [] as string[] };
 
-  console.log(relationshipsWithNextPage);
-
   return {
     relationships,
     relationshipsWithNextPage,

--- a/src/hooks/objects/get/useGetObjectRelationships.ts
+++ b/src/hooks/objects/get/useGetObjectRelationships.ts
@@ -30,12 +30,47 @@ import { getObjectTypeFromListingTypeName, hasProperty } from "src/lib/utils";
 
 import { GetObjectOptions } from "./useGetObject";
 
+type PageParam = Record<string, string>;
+
 const getFieldsFromObjectType = (
   objects: SkylarkObjectMeta[] | null,
   objectType: string,
 ) => {
   const object = objects?.find(({ name }) => name === objectType);
   return object?.fields || [];
+};
+
+const getRelationshipNextTokens = (
+  response: GQLSkylarkGetObjectRelationshipsResponse,
+) => {
+  const data = response.getObjectRelationships;
+  return Object.keys(data).reduce(
+    (prev, relationshipName) => {
+      const relationship = data[
+        relationshipName
+      ] as SkylarkGraphQLObjectRelationship;
+
+      if (relationship.next_token) {
+        return {
+          ...prev,
+          requestVariables: {
+            ...prev.requestVariables,
+            [`${relationshipName}NextToken`]: relationship.next_token,
+          },
+          relationshipsWithNextPage: [
+            ...prev.relationshipsWithNextPage,
+            relationshipName,
+          ],
+        };
+      }
+
+      return prev;
+    },
+    { requestVariables: {}, relationshipsWithNextPage: [] } as {
+      requestVariables: Record<string, string>;
+      relationshipsWithNextPage: string[];
+    },
+  );
 };
 
 export const createGetObjectRelationshipsKeyPrefix = ({
@@ -75,7 +110,7 @@ export const useGetObjectRelationships = (
       GQLSkylarkErrorResponse<GQLSkylarkGetObjectResponse>,
       InfiniteData<GQLSkylarkGetObjectRelationshipsResponse>,
       QueryKey,
-      Record<string, string>
+      PageParam
     >({
       // eslint-disable-next-line @tanstack/query/exhaustive-deps
       queryKey: createGetObjectRelationshipsKeyPrefix({ objectType, uid }),
@@ -86,35 +121,19 @@ export const useGetObjectRelationships = (
         }),
       initialPageParam: {},
       getNextPageParam: (lastPage): Record<string, string> | undefined => {
-        const data = lastPage.getObjectRelationships;
-        const allNextTokens = Object.keys(data).reduce(
-          (prev, relationshipName) => {
-            const relationship = data[
-              relationshipName
-            ] as SkylarkGraphQLObjectRelationship;
+        const { requestVariables, relationshipsWithNextPage } =
+          getRelationshipNextTokens(lastPage);
 
-            if (relationship.next_token) {
-              return {
-                ...prev,
-                [`${relationshipName}NextToken`]: relationship.next_token,
-              };
-            }
-
-            return prev;
-          },
-          {} as Record<string, string>,
-        );
-
-        return Object.keys(allNextTokens).length > 0
-          ? allNextTokens
+        return relationshipsWithNextPage.length > 0
+          ? requestVariables
           : undefined;
       },
       enabled: query !== null,
     });
 
-  if (hasNextPage) {
-    fetchNextPage();
-  }
+  // if (hasNextPage) {
+  //   fetchNextPage();
+  // }
 
   const relationships: ParsedSkylarkObjectRelationships | null = useMemo(() => {
     if (!data?.pages || data.pages.length === 0) {
@@ -153,12 +172,20 @@ export const useGetObjectRelationships = (
     }, {} as ParsedSkylarkObjectRelationships);
   }, [data?.pages]);
 
+  const { relationshipsWithNextPage } = data
+    ? getRelationshipNextTokens(data.pages[data.pages.length - 1])
+    : { relationshipsWithNextPage: [] as string[] };
+
+  console.log(relationshipsWithNextPage);
+
   return {
     relationships,
+    relationshipsWithNextPage,
     objectRelationships: objectOperations?.relationships,
     isLoading: isLoading || !query,
     isFetchingNextPage,
     query,
     variables,
+    fetchNextPage,
   };
 };

--- a/src/hooks/state/usePanelObjectState.tsx
+++ b/src/hooks/state/usePanelObjectState.tsx
@@ -16,7 +16,7 @@ export enum PanelTab {
 
 export interface PanelTabState {
   [PanelTab.Relationships]: {
-    expanded: Record<string, boolean>;
+    active: string | null;
   };
 }
 
@@ -27,7 +27,7 @@ export interface PanelObject extends SkylarkObjectIdentifier {
 
 const defaultPanelTabState: PanelTabState = {
   [PanelTab.Relationships]: {
-    expanded: {},
+    active: null,
   },
 };
 
@@ -39,10 +39,6 @@ export const mergedPanelTabStates = (
     [PanelTab.Relationships]: {
       ...previousState[PanelTab.Relationships],
       ...newState?.[PanelTab.Relationships],
-      expanded: {
-        ...previousState[PanelTab.Relationships].expanded,
-        ...newState?.[PanelTab.Relationships]?.expanded,
-      },
     },
   };
 };

--- a/src/pages/object/[objectType]/[uid].tsx
+++ b/src/pages/object/[objectType]/[uid].tsx
@@ -14,7 +14,7 @@ const Object = () => {
 
   const [tabState, setTabState] = useState<PanelTabState>({
     [PanelTab.Relationships]: {
-      expanded: {},
+      active: null,
     },
   });
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -42,6 +42,7 @@ module.exports = {
       },
       transitionProperty: {
         width: "width",
+        "grid-template-rows": "grid-template-rows",
       },
       animation: {
         "spin-fast": "spin 0.5s linear infinite",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -42,7 +42,6 @@ module.exports = {
       },
       transitionProperty: {
         width: "width",
-        "grid-template-rows": "grid-template-rows",
       },
       animation: {
         "spin-fast": "spin 0.5s linear infinite",


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->

- Refactors the Relationships Panel so that to view more on a relationship, you expand it. This change means that pagination for relationships will only happen when the user has scrolled to the end or loaded more.

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Feature

#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://skylarkplatform.atlassian.net/browse/SL-2916

