### PR TITLE
feat: when dragging into the relationships panel, use the active relationship (if any) as the target object type

### DIFF
--- a/cypress/e2e/contentLibrary/dragdrop.cy.ts
+++ b/cypress/e2e/contentLibrary/dragdrop.cy.ts
@@ -9,6 +9,44 @@ const allDevicesAllCustomersAvailability =
 const panelDragDeltaX = 1800;
 const panelDragDeltaY = 500;
 
+const searchContentLibrary = (str: string) => {
+  cy.get('input[name="search-query-input"]').clear().type(str);
+  cy.contains(str).should("exist");
+};
+
+const searchContentLibraryAndOpenPanel = (str: string) => {
+  searchContentLibrary(str);
+  cy.openContentLibraryObjectPanelByText(str);
+};
+
+const dragRowIntoPanel = (row: "first" | "last") => {
+  const allRows = cy.get(`[data-cy="object-search-results-row-draggable"`);
+  const cyRow = row === "first" ? allRows.first() : allRows.last();
+
+  return cyRow
+    .trigger("mousedown", {
+      button: 0,
+      release: false,
+      force: true,
+    })
+    .trigger("mousemove", {
+      force: true,
+      clientX: 20,
+      clientY: 20,
+    })
+    .wait(100)
+    .trigger("mousemove", {
+      force: true,
+      clientX: panelDragDeltaX,
+      clientY: panelDragDeltaY,
+    })
+    .then(() => {
+      cy.get("[data-cy=panel-drop-zone]").should("exist");
+    })
+    .wait(50)
+    .trigger("mouseup", { force: true });
+};
+
 describe("Drag and Drop - Content and Relationship tab", () => {
   beforeEach(() => {
     cy.login();
@@ -89,44 +127,18 @@ describe("Drag and Drop - Content and Relationship tab", () => {
             const homepageUid = homepageJson.data.getObject.uid;
             const homepageObjectType = homepageJson.data.getObject.__typename;
 
-            cy.get('input[name="search-query-input"]').type("Homepage");
-            cy.contains("Homepage").should("exist");
-            cy.openContentLibraryObjectPanelByText("Homepage");
+            searchContentLibraryAndOpenPanel("Homepage");
             cy.contains("button", "Content").click();
             cy.get(`[data-cy=panel-for-${homepageObjectType}-${homepageUid}]`);
 
             cy.get("[data-cy=panel-drop-zone]").should("not.exist");
 
-            cy.get(`[data-cy="object-search-results-row-draggable"`)
-              .last()
-              .trigger("mousedown", {
-                button: 0,
-                release: false,
-                force: true,
-              })
-              .trigger("mousemove", {
-                force: true,
-                clientX: 20,
-                clientY: 20,
-              })
-              .wait(500)
-              .trigger("mousemove", {
-                force: true,
-                clientX: panelDragDeltaX,
-                clientY: panelDragDeltaY,
-              })
-              .then(() => {
-                cy.get("[data-cy=panel-drop-zone]").should("exist");
-              })
-              .wait(100)
-              .trigger("mouseup", { force: true })
-              .wait(250)
-              .then(() => {
-                cy.contains("button", "Content").should("exist");
-                cy.get("input.bg-success")
-                  .should("exist")
-                  .should("have.length", 1);
-              });
+            dragRowIntoPanel("last").then(() => {
+              cy.contains("button", "Content").should("exist");
+              cy.get("input.bg-success")
+                .should("exist")
+                .should("have.length", 1);
+            });
           },
         );
       });
@@ -137,74 +149,24 @@ describe("Drag and Drop - Content and Relationship tab", () => {
             const homepageUid = homepageJson.data.getObject.uid;
             const homepageObjectType = homepageJson.data.getObject.__typename;
 
-            cy.get('input[name="search-query-input"]').type("Homepage");
-            cy.contains("Homepage").should("exist");
-            cy.openContentLibraryObjectPanelByText("Homepage");
+            searchContentLibraryAndOpenPanel("Homepage");
             cy.contains("button", "Content").click();
             cy.get(`[data-cy=panel-for-${homepageObjectType}-${homepageUid}]`);
 
             cy.get("[data-cy=panel-drop-zone]").should("not.exist");
 
-            cy.get(`[data-cy="object-search-results-row-draggable"`)
-              .last()
-              .trigger("mousedown", {
-                button: 0,
-                release: false,
-                force: true,
-              })
-              .trigger("mousemove", {
-                force: true,
-                clientX: 20,
-                clientY: 20,
-              })
-              .wait(500)
-              .trigger("mousemove", {
-                force: true,
-                clientX: panelDragDeltaX,
-                clientY: panelDragDeltaY,
-              })
-              .then(() => {
-                cy.get("[data-cy=panel-drop-zone]").should("exist");
-              })
-              .wait(100)
-              .trigger("mouseup", { force: true })
-              .wait(250)
-              .then(() => {
-                cy.contains("button", "Content").should("exist");
-                cy.get("input.bg-success")
-                  .should("exist")
-                  .should("have.length", 1);
-              });
+            dragRowIntoPanel("last").then(() => {
+              cy.contains("button", "Content").should("exist");
+              cy.get("input.bg-success")
+                .should("exist")
+                .should("have.length", 1);
+            });
 
-            cy.get(`[data-cy="object-search-results-row-draggable"`)
-              .last()
-              .trigger("mousedown", {
-                button: 0,
-                release: false,
-                force: true,
-              })
-              .trigger("mousemove", {
-                force: true,
-                clientX: 20,
-                clientY: 20,
-              })
-              .wait(500)
-              .trigger("mousemove", {
-                force: true,
-                clientX: panelDragDeltaX,
-                clientY: panelDragDeltaY,
-              })
-              .then(() => {
-                cy.get("[data-cy=panel-drop-zone]").should("exist");
-              })
-              .wait(100)
-              .trigger("mouseup", { force: true })
-              .wait(250)
-              .then(() => {
-                cy.get("[data-testid=toast]").within(() => {
-                  cy.contains("Existing Linked Object").should("exist");
-                });
+            dragRowIntoPanel("last").then(() => {
+              cy.get("[data-testid=toast]").within(() => {
+                cy.contains("Existing Linked Object").should("exist");
               });
+            });
           },
         );
       });
@@ -217,43 +179,17 @@ describe("Drag and Drop - Content and Relationship tab", () => {
             const homepageUid = homepageJson.data.getObject.uid;
             const homepageObjectType = homepageJson.data.getObject.__typename;
 
-            cy.get('input[name="search-query-input"]').type("Homepage");
-            cy.contains("Homepage").should("exist");
-            cy.openContentLibraryObjectPanelByText("Homepage");
+            searchContentLibraryAndOpenPanel("Homepage");
             cy.contains("button", "Relationships").click();
             cy.get(`[data-cy=panel-for-${homepageObjectType}-${homepageUid}]`);
 
             cy.get("[data-cy=panel-drop-zone]").should("not.exist");
 
-            cy.get(`[data-cy="object-search-results-row-draggable"`)
-              .last()
-              .trigger("mousedown", {
-                button: 0,
-                release: false,
-                force: true,
-              })
-              .trigger("mousemove", {
-                force: true,
-                clientX: 20,
-                clientY: 20,
-              })
-              .then(() => {
-                cy.get("[data-cy=panel-drop-zone]").should("exist");
-              })
-              .wait(500)
-              .trigger("mousemove", {
-                force: true,
-                clientX: panelDragDeltaX,
-                clientY: panelDragDeltaY,
-              })
-              .wait(100)
-              .trigger("mouseup", { force: true })
-              .wait(250)
-              .then(() => {
-                cy.get("span.bg-success")
-                  .should("exist")
-                  .should("have.length", 1);
-              });
+            dragRowIntoPanel("last").then(() => {
+              cy.get("span.bg-success")
+                .should("exist")
+                .should("have.length", 1);
+            });
           },
         );
       });
@@ -264,73 +200,23 @@ describe("Drag and Drop - Content and Relationship tab", () => {
             const homepageUid = homepageJson.data.getObject.uid;
             const homepageObjectType = homepageJson.data.getObject.__typename;
 
-            cy.get('input[name="search-query-input"]').type("Homepage");
-            cy.contains("Homepage").should("exist");
-            cy.openContentLibraryObjectPanelByText("Homepage");
+            searchContentLibraryAndOpenPanel("Homepage");
             cy.contains("button", "Relationships").click();
             cy.get(`[data-cy=panel-for-${homepageObjectType}-${homepageUid}]`);
 
             cy.get("[data-cy=panel-drop-zone]").should("not.exist");
 
-            cy.get(`[data-cy="object-search-results-row-draggable"`)
-              .last()
-              .trigger("mousedown", {
-                button: 0,
-                release: false,
-                force: true,
-              })
-              .trigger("mousemove", {
-                force: true,
-                clientX: 20,
-                clientY: 20,
-              })
-              .then(() => {
-                cy.get("[data-cy=panel-drop-zone]").should("exist");
-              })
-              .wait(500)
-              .trigger("mousemove", {
-                force: true,
-                clientX: panelDragDeltaX,
-                clientY: panelDragDeltaY,
-              })
-              .wait(100)
-              .trigger("mouseup", { force: true })
-              .wait(250)
-              .then(() => {
-                cy.get("span.bg-success")
-                  .should("exist")
-                  .should("have.length", 1);
-              });
+            dragRowIntoPanel("last").then(() => {
+              cy.get("span.bg-success")
+                .should("exist")
+                .should("have.length", 1);
+            });
 
-            cy.get(`[data-cy="object-search-results-row-draggable"`)
-              .last()
-              .trigger("mousedown", {
-                button: 0,
-                release: false,
-                force: true,
-              })
-              .trigger("mousemove", {
-                force: true,
-                clientX: 20,
-                clientY: 20,
-              })
-              .then(() => {
-                cy.get("[data-cy=panel-drop-zone]").should("exist");
-              })
-              .wait(500)
-              .trigger("mousemove", {
-                force: true,
-                clientX: panelDragDeltaX,
-                clientY: panelDragDeltaY,
-              })
-              .wait(100)
-              .trigger("mouseup", { force: true })
-              .wait(250)
-              .then(() => {
-                cy.get("[data-testid=toast]").within(() => {
-                  cy.contains("Existing Linked Object").should("exist");
-                });
+            dragRowIntoPanel("last").then(() => {
+              cy.get("[data-testid=toast]").within(() => {
+                cy.contains("Existing Linked Object").should("exist");
               });
+            });
           },
         );
       });
@@ -341,43 +227,19 @@ describe("Drag and Drop - Content and Relationship tab", () => {
             const homepageUid = homepageJson.data.getObject.uid;
             const homepageObjectType = homepageJson.data.getObject.__typename;
 
-            cy.get('input[name="search-query-input"]').type("Homepage");
-            cy.contains("Homepage").should("exist");
-            cy.openContentLibraryObjectPanelByText("Homepage");
+            searchContentLibraryAndOpenPanel("Homepage");
             cy.contains("button", "Relationships").click();
             cy.get(`[data-cy=panel-for-${homepageObjectType}-${homepageUid}]`);
 
             cy.get("[data-cy=panel-drop-zone]").should("not.exist");
 
-            cy.get(`[data-cy="object-search-results-row-draggable"`)
-              .first()
-              .trigger("mousedown", {
-                button: 0,
-                release: false,
-                force: true,
-              })
-              .trigger("mousemove", {
-                force: true,
-                clientX: 20,
-                clientY: 20,
-              })
-              .then(() => {
-                cy.get("[data-cy=panel-drop-zone]").should("exist");
-              })
-              .wait(500)
-              .trigger("mousemove", {
-                force: true,
-                clientX: panelDragDeltaX,
-                clientY: panelDragDeltaY,
-              })
-              .wait(100)
-              .trigger("mouseup", { force: true })
-              .wait(250)
-              .then(() => {
-                cy.get("[data-testid=toast]").within(() => {
+            dragRowIntoPanel("first").then(() => {
+              cy.get("[data-testid=toast]")
+                .first()
+                .within(() => {
                   cy.contains("Invalid Object Type").should("exist");
                 });
-              });
+            });
           },
         );
       });
@@ -390,53 +252,21 @@ describe("Drag and Drop - Content and Relationship tab", () => {
             const homepageUid = homepageJson.data.getObject.uid;
             const homepageObjectType = homepageJson.data.getObject.__typename;
 
-            cy.get('input[name="search-query-input"]').type("Homepage");
-            cy.contains("Homepage").should("exist");
-            cy.openContentLibraryObjectPanelByText("Homepage");
+            searchContentLibraryAndOpenPanel("Homepage");
             cy.get("[data-testid=panel-tabs]").within(() => {
               cy.contains("button", "Availability").click();
             });
             cy.get(`[data-cy=panel-for-${homepageObjectType}-${homepageUid}]`);
 
-            cy.get('input[name="search-query-input"]')
-              .clear()
-              .type(allDevicesAllCustomersAvailability);
-
-            cy.contains(allDevicesAllCustomersAvailability).should("exist");
+            searchContentLibrary(allDevicesAllCustomersAvailability);
 
             cy.get("[data-cy=panel-drop-zone]").should("not.exist");
 
-            cy.get(`[data-cy="object-search-results-row-draggable"`)
-              .last()
-              .trigger("mousedown", {
-                button: 0,
-                release: false,
-                force: true,
-              })
-              .trigger("mousemove", {
-                force: true,
-                clientX: 20,
-                clientY: 20,
-              })
-              .then(() => {
-                cy.get("[data-cy=panel-drop-zone]").should("exist");
-              })
-              .wait(500)
-              .trigger("mousemove", {
-                force: true,
-                clientX: panelDragDeltaX,
-                clientY: panelDragDeltaY,
-              })
-              .wait(100)
-              .trigger("mouseup", { force: true })
-              .wait(250)
-              .then(() => {
-                cy.get("[data-testid=panel]").within(() => {
-                  cy.contains(allDevicesAllCustomersAvailability).should(
-                    "exist",
-                  );
-                });
+            dragRowIntoPanel("last").then(() => {
+              cy.get("[data-testid=panel]").within(() => {
+                cy.contains(allDevicesAllCustomersAvailability).should("exist");
               });
+            });
           },
         );
       });
@@ -447,83 +277,27 @@ describe("Drag and Drop - Content and Relationship tab", () => {
             const homepageUid = homepageJson.data.getObject.uid;
             const homepageObjectType = homepageJson.data.getObject.__typename;
 
-            cy.get('input[name="search-query-input"]').type("Homepage");
-            cy.contains("Homepage").should("exist");
-            cy.openContentLibraryObjectPanelByText("Homepage");
+            searchContentLibraryAndOpenPanel("Homepage");
             cy.get("[data-testid=panel-tabs]").within(() => {
               cy.contains("button", "Availability").click();
             });
             cy.get(`[data-cy=panel-for-${homepageObjectType}-${homepageUid}]`);
 
-            cy.get('input[name="search-query-input"]')
-              .clear()
-              .type(allDevicesAllCustomersAvailability);
-
-            cy.contains(allDevicesAllCustomersAvailability).should("exist");
+            searchContentLibrary(allDevicesAllCustomersAvailability);
 
             cy.get("[data-cy=panel-drop-zone]").should("not.exist");
 
-            cy.get(`[data-cy="object-search-results-row-draggable"`)
-              .last()
-              .trigger("mousedown", {
-                button: 0,
-                release: false,
-                force: true,
-              })
-              .trigger("mousemove", {
-                force: true,
-                clientX: 20,
-                clientY: 20,
-              })
-              .then(() => {
-                cy.get("[data-cy=panel-drop-zone]").should("exist");
-              })
-              .wait(500)
-              .trigger("mousemove", {
-                force: true,
-                clientX: panelDragDeltaX,
-                clientY: panelDragDeltaY,
-              })
-              .wait(100)
-              .trigger("mouseup", { force: true })
-              .wait(250)
-              .then(() => {
-                cy.get("[data-testid=panel]").within(() => {
-                  cy.contains(allDevicesAllCustomersAvailability).should(
-                    "exist",
-                  );
-                });
+            dragRowIntoPanel("last").then(() => {
+              cy.get("[data-testid=panel]").within(() => {
+                cy.contains(allDevicesAllCustomersAvailability).should("exist");
               });
+            });
 
-            cy.get(`[data-cy="object-search-results-row-draggable"`)
-              .last()
-              .trigger("mousedown", {
-                button: 0,
-                release: false,
-                force: true,
-              })
-              .trigger("mousemove", {
-                force: true,
-                clientX: 20,
-                clientY: 20,
-              })
-              .then(() => {
-                cy.get("[data-cy=panel-drop-zone]").should("exist");
-              })
-              .wait(500)
-              .trigger("mousemove", {
-                force: true,
-                clientX: panelDragDeltaX,
-                clientY: panelDragDeltaY,
-              })
-              .wait(100)
-              .trigger("mouseup", { force: true })
-              .wait(250)
-              .then(() => {
-                cy.get("[data-testid=toast]").within(() => {
-                  cy.contains(`Existing Linked Object`).should("exist");
-                });
+            dragRowIntoPanel("last").then(() => {
+              cy.get("[data-testid=toast]").within(() => {
+                cy.contains(`Existing Linked Object`).should("exist");
               });
+            });
           },
         );
       });
@@ -534,9 +308,7 @@ describe("Drag and Drop - Content and Relationship tab", () => {
             const homepageUid = homepageJson.data.getObject.uid;
             const homepageObjectType = homepageJson.data.getObject.__typename;
 
-            cy.get('input[name="search-query-input"]').type("Homepage");
-            cy.contains("Homepage").should("exist");
-            cy.openContentLibraryObjectPanelByText("Homepage");
+            searchContentLibraryAndOpenPanel("Homepage");
             cy.get("[data-testid=panel-tabs]").within(() => {
               cy.contains("button", "Availability").click();
             });
@@ -544,35 +316,11 @@ describe("Drag and Drop - Content and Relationship tab", () => {
 
             cy.get("[data-cy=panel-drop-zone]").should("not.exist");
 
-            cy.get(`[data-cy="object-search-results-row-draggable"`)
-              .last()
-              .trigger("mousedown", {
-                button: 0,
-                release: false,
-                force: true,
-              })
-              .trigger("mousemove", {
-                force: true,
-                clientX: 20,
-                clientY: 20,
-              })
-              .then(() => {
-                cy.get("[data-cy=panel-drop-zone]").should("exist");
-              })
-              .wait(500)
-              .trigger("mousemove", {
-                force: true,
-                clientX: panelDragDeltaX,
-                clientY: panelDragDeltaY,
-              })
-              .wait(100)
-              .trigger("mouseup", { force: true })
-              .wait(250)
-              .then(() => {
-                cy.get("[data-testid=toast]").within(() => {
-                  cy.contains("Invalid Object Type").should("exist");
-                });
+            dragRowIntoPanel("last").then(() => {
+              cy.get("[data-testid=toast]").within(() => {
+                cy.contains("Invalid Object Type").should("exist");
               });
+            });
           },
         );
       });
@@ -580,19 +328,13 @@ describe("Drag and Drop - Content and Relationship tab", () => {
 
     describe("Availability Assigned To", () => {
       it("drags an object to add it", () => {
-        cy.get('input[name="search-query-input"]')
-          .clear()
-          .type(allDevicesAllCustomersAvailability);
-        cy.openContentLibraryObjectPanelByText(
-          allDevicesAllCustomersAvailability,
-        );
+        searchContentLibraryAndOpenPanel(allDevicesAllCustomersAvailability);
 
         cy.contains("Assigned To").click();
 
         cy.contains("Assign to multiple objects dropzone");
 
-        cy.get('input[name="search-query-input"]').clear().type("Homepage");
-        cy.contains("Homepage").should("exist");
+        searchContentLibrary("Homepage");
 
         cy.get("[data-cy=panel-drop-zone]").should("not.exist");
 
@@ -628,12 +370,7 @@ describe("Drag and Drop - Content and Relationship tab", () => {
       });
 
       it("shows an error toast when an Availability object is dragged into the drop zone", () => {
-        cy.get('input[name="search-query-input"]')
-          .clear()
-          .type(allDevicesAllCustomersAvailability);
-        cy.openContentLibraryObjectPanelByText(
-          allDevicesAllCustomersAvailability,
-        );
+        searchContentLibraryAndOpenPanel(allDevicesAllCustomersAvailability);
 
         cy.contains("Assigned To").click();
 

--- a/cypress/e2e/contentLibrary/dragdrop.cy.ts
+++ b/cypress/e2e/contentLibrary/dragdrop.cy.ts
@@ -194,6 +194,62 @@ describe("Drag and Drop - Content and Relationship tab", () => {
         );
       });
 
+      it("expands the images relationship and adds an object by dragging", () => {
+        cy.fixture("./skylark/queries/getObject/homepage.json").then(
+          (homepageJson) => {
+            const homepageUid = homepageJson.data.getObject.uid;
+            const homepageObjectType = homepageJson.data.getObject.__typename;
+
+            searchContentLibraryAndOpenPanel("Homepage");
+            cy.contains("button", "Relationships").click();
+            cy.get(`[data-cy=panel-for-${homepageObjectType}-${homepageUid}]`);
+
+            cy.get("[data-cy=panel-drop-zone]").should("not.exist");
+
+            // Expand images relationship
+            cy.get("#panel-section-call_to_actions").should("exist");
+            cy.get('[aria-label="expand images relationship"]').click();
+            cy.get("#panel-section-call_to_actions").should("not.exist");
+
+            dragRowIntoPanel("last").then(() => {
+              cy.get("span.bg-success")
+                .should("exist")
+                .should("have.length", 1);
+            });
+          },
+        );
+      });
+
+      it("expands the images relationship and shows an error toast when an invalid object type is dragged", () => {
+        cy.fixture("./skylark/queries/getObject/homepage.json").then(
+          (homepageJson) => {
+            const homepageUid = homepageJson.data.getObject.uid;
+            const homepageObjectType = homepageJson.data.getObject.__typename;
+
+            searchContentLibraryAndOpenPanel("Homepage");
+            cy.contains("button", "Relationships").click();
+            cy.get(`[data-cy=panel-for-${homepageObjectType}-${homepageUid}]`);
+
+            cy.get("[data-cy=panel-drop-zone]").should("not.exist");
+
+            // Expand images relationship
+            cy.get("#panel-section-call_to_actions").should("exist");
+            cy.get('[aria-label="expand images relationship"]').click();
+            cy.get("#panel-section-call_to_actions").should("not.exist");
+
+            dragRowIntoPanel("first").then(() => {
+              cy.get("[data-testid=toast]")
+                .first()
+                .within(() => {
+                  cy.contains("Invalid Object Type for Relationship").should(
+                    "exist",
+                  );
+                });
+            });
+          },
+        );
+      });
+
       it("shows an error toast when the relationship already exists", () => {
         cy.fixture("./skylark/queries/getObject/homepage.json").then(
           (homepageJson) => {

--- a/src/components/availability/summary/availabilitySummary.component.tsx
+++ b/src/components/availability/summary/availabilitySummary.component.tsx
@@ -2,8 +2,10 @@ import clsx from "clsx";
 
 import { useAvailabilityDimensionsWithValues } from "src/hooks/availability/useAvailabilityDimensionWithValues";
 import { SearchType } from "src/hooks/useSearchWithLookupType";
-import { useSkylarkObjectTypesWithConfig } from "src/hooks/useSkylarkObjectTypes";
-import { ParsedSkylarkObjectConfig } from "src/interfaces/skylark";
+import {
+  ObjectTypeWithConfig,
+  useSkylarkObjectTypesWithConfig,
+} from "src/hooks/useSkylarkObjectTypes";
 import { formatReadableDateTime } from "src/lib/skylark/availability";
 
 const prettifyStrArr = (arr: string[]): string => {
@@ -21,10 +23,7 @@ const prettifyStrArr = (arr: string[]): string => {
 const buildObjectTypesStr = (
   filteredObjectTypes: string[] | null,
   numObjectTypes?: number,
-  allObjectTypesWithConfig?: {
-    objectType: string;
-    config: ParsedSkylarkObjectConfig;
-  }[],
+  allObjectTypesWithConfig?: ObjectTypeWithConfig[],
 ) => {
   // If object types are null, search will fetch all
   if (

--- a/src/components/contentModel/navigation/contentModelNavigation.component.tsx
+++ b/src/components/contentModel/navigation/contentModelNavigation.component.tsx
@@ -6,8 +6,8 @@ import { useEffect } from "react";
 import {
   useSkylarkSetObjectTypes,
   useSkylarkObjectTypesWithConfig,
+  ObjectTypeWithConfig,
 } from "src/hooks/useSkylarkObjectTypes";
-import { ParsedSkylarkObjectConfig } from "src/interfaces/skylark";
 import { isSkylarkObjectType } from "src/lib/utils";
 
 interface ObjectTypeNavigationProps {
@@ -21,10 +21,7 @@ const ObjectTypeNavigationSection = ({
 }: {
   title: string;
   activeObjectType: string | null;
-  objectTypesWithConfig: {
-    objectType: string;
-    config: ParsedSkylarkObjectConfig;
-  }[];
+  objectTypesWithConfig?: ObjectTypeWithConfig[];
 }) => (
   <div className="flex flex-col justify-start items-start my-4 w-full">
     <p className="mb-1 font-medium text-lg">{title}</p>

--- a/src/components/navigation/navigation/navigation.component.tsx
+++ b/src/components/navigation/navigation/navigation.component.tsx
@@ -3,7 +3,7 @@ import clsx from "clsx";
 import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
-import { FiLogOut } from "react-icons/fi";
+import { FiGithub, FiLogOut } from "react-icons/fi";
 import { useIsClient } from "usehooks-ts";
 
 import { AccountStatus } from "src/components/account";
@@ -72,6 +72,12 @@ export const Navigation = () => {
                 text: "Change Skylark Account",
                 onClick: () => setAuthModalOpen(true),
                 Icon: <FiLogOut className="text-xl" />,
+              },
+              {
+                id: "skylark-ui-github",
+                text: "GitHub",
+                href: "https://github.com/skylark-platform/skylark-ui",
+                Icon: <FiGithub className="text-xl" />,
               },
             ]}
             placement="bottom-end"

--- a/src/components/panel/__tests__/tabs/relationships.test.tsx
+++ b/src/components/panel/__tests__/tabs/relationships.test.tsx
@@ -183,6 +183,37 @@ describe("relationships view", () => {
     );
   });
 
+  test("makes a relationship active using the side navigation when in page mode", async () => {
+    render(
+      <Panel
+        {...defaultProps}
+        isPage
+        object={seasonWithRelationships}
+        tab={PanelTab.Relationships}
+      />,
+    );
+
+    const withinSideNavigation = within(
+      screen.getByTestId("panel-page-side-navigation"),
+    );
+
+    await waitFor(() => expect(screen.getAllByText("Episode")).toHaveLength(5));
+    await waitFor(() =>
+      expect(screen.queryByTestId("brands")).toBeInTheDocument(),
+    );
+
+    const navigationButton = withinSideNavigation.getByText("Episodes");
+    fireEvent.click(navigationButton);
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Episode")).toHaveLength(10),
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("brands")).not.toBeInTheDocument(),
+    );
+  });
+
   test("calls updateActivePanelTabState with the selected relationship info when it is made active", async () => {
     const updateActivePanelTabState = jest.fn();
     render(

--- a/src/components/panel/panel.component.tsx
+++ b/src/components/panel/panel.component.tsx
@@ -20,7 +20,10 @@ import { useUpdateObjectContent } from "src/hooks/objects/update/useUpdateObject
 import { useUpdateObjectMetadata } from "src/hooks/objects/update/useUpdateObjectMetadata";
 import { useUpdateObjectRelationships } from "src/hooks/objects/update/useUpdateObjectRelationships";
 import { PanelTab, PanelTabState } from "src/hooks/state";
-import { useSkylarkObjectTypesWithConfig } from "src/hooks/useSkylarkObjectTypes";
+import {
+  ObjectTypeWithConfig,
+  useSkylarkObjectTypesWithConfig,
+} from "src/hooks/useSkylarkObjectTypes";
 import {
   ParsedSkylarkObjectContentObject,
   ParsedSkylarkObject,
@@ -88,10 +91,7 @@ const displayHandleDroppedErrors = (
   errors: HandleDropError[],
   tab: PanelTab,
   panelObject?: ParsedSkylarkObject,
-  objectTypesWithConfig?: {
-    objectType: string;
-    config: ParsedSkylarkObjectConfig;
-  }[],
+  objectTypesWithConfig?: ObjectTypeWithConfig[],
 ) => {
   const objectTypeConfigObject:
     | Record<string, ParsedSkylarkObjectConfig>

--- a/src/components/panel/panel.component.tsx
+++ b/src/components/panel/panel.component.tsx
@@ -40,6 +40,7 @@ import {
   handleDroppedContents,
   HandleDropError,
   HandleDropErrorType,
+  HandleRelationshipDropError,
 } from "./panel.lib";
 import {
   PanelAvailability,
@@ -134,7 +135,52 @@ const displayHandleDroppedErrors = (
       <Toast
         title={`Invalid Object Type${invalidObjectTypes.length > 1 ? "s" : ""}`}
         message={[
-          `Types "${invalidObjectTypes.join(", ")}" ${tabText}.`,
+          `Type${
+            invalidObjectTypes.length > 1 ? "s" : ""
+          } "${invalidObjectTypes.join(", ")}" ${tabText}.`,
+          `Affected object(s):`,
+          ...affectedObjectsMsg,
+        ]}
+      />,
+      { autoClose: 10000 },
+    );
+  }
+
+  const invalidRelationshipTypeErrors = errors.filter(
+    (error) => error.type === HandleDropErrorType.INVALID_RELATIONSHIP_TYPE,
+  );
+
+  if (invalidRelationshipTypeErrors.length > 0) {
+    const invalidObjectTypes = [
+      ...new Set(
+        invalidRelationshipTypeErrors.map(({ object }) =>
+          getObjectTypeDisplayNameFromParsedObject(object),
+        ),
+      ),
+    ];
+
+    const relationshipName = (
+      invalidRelationshipTypeErrors.find(
+        (error) =>
+          error.type === HandleDropErrorType.INVALID_RELATIONSHIP_TYPE &&
+          error.targetRelationship,
+      ) as HandleRelationshipDropError
+    )?.targetRelationship;
+
+    const relationshipTypeText = relationshipName || "Active relationship";
+
+    const affectedObjectsMsg = invalidRelationshipTypeErrors.map(
+      ({ object }) => `- ${getObjectDisplayName(object)}`,
+    );
+    toast.error(
+      <Toast
+        title={`Invalid Object Type${invalidObjectTypes.length > 1 ? "s" : ""}`}
+        message={[
+          `Type${
+            invalidObjectTypes.length > 1 ? "s" : ""
+          } "${invalidObjectTypes.join(
+            ", ",
+          )}" cannot be linked to the relationship "${relationshipTypeText}".`,
           `Affected object(s):`,
           ...affectedObjectsMsg,
         ]}

--- a/src/components/panel/panelSections/panelHeader.component.tsx
+++ b/src/components/panel/panelSections/panelHeader.component.tsx
@@ -392,7 +392,7 @@ export const PanelHeader = ({
           {(inEditMode || currentTab === PanelTab.Metadata) && (
             <div
               className={clsx(
-                "absolute -bottom-16 left-1/2 z-10 -translate-x-1/2",
+                "absolute -bottom-16 left-1/2 z-20 -translate-x-1/2",
                 isPage ? "md:fixed md:bottom-auto md:top-24" : " md:-bottom-18",
               )}
             >

--- a/src/components/panel/panelSections/panelRelationships.component.tsx
+++ b/src/components/panel/panelSections/panelRelationships.component.tsx
@@ -381,7 +381,7 @@ export const PanelRelationships = ({
           {!activeRelationship &&
             orderedRelationships.length > 0 &&
             emptyOrderedRelationships.length > 0 && (
-              <PanelSeparator className="my-8" />
+              <PanelSeparator className="mb-8" />
             )}
 
           {filterWhenExpandedRelationship(

--- a/src/components/panel/panelSections/panelRelationships.component.tsx
+++ b/src/components/panel/panelSections/panelRelationships.component.tsx
@@ -217,6 +217,10 @@ export const PanelRelationships = ({
   setPanelObject,
   updateActivePanelTabState,
 }: PanelRelationshipsProps) => {
+  const [activeRelationship, setActiveRelationship] = useState<string | null>(
+    tabState.active,
+  );
+
   const {
     relationships: serverRelationships,
     relationshipsWithNextPage,
@@ -254,6 +258,7 @@ export const PanelRelationships = ({
         activeObjectUid: uid,
         existingObjects: relationships,
         objectMetaRelationships,
+        targetRelationship: activeRelationship,
       });
 
       setModifiedRelationships(
@@ -265,6 +270,7 @@ export const PanelRelationships = ({
       );
     }
   }, [
+    activeRelationship,
     droppedObjects,
     modifiedRelationships,
     objectMetaRelationships,
@@ -299,10 +305,6 @@ export const PanelRelationships = ({
   );
 
   const scrollDivRef = useRef<HTMLDivElement | null>(null);
-
-  const [activeRelationship, setActiveRelationship] = useState<string | null>(
-    tabState.active,
-  );
 
   const setActiveRelationshipWrapper = useCallback(
     (name: string | null) => {
@@ -403,7 +405,6 @@ export const PanelRelationships = ({
                   relationship.name,
                   modifiedRelationships,
                 )}
-                fetchMoreRelationships={() => ""} // TODO convert this section into PanelEmptyRelationshipSection
                 setPanelObject={setPanelObject}
                 removeRelationshipObject={({ relationshipName, uid }) => {
                   modifyRelationshipObjects(relationshipName, {
@@ -465,7 +466,7 @@ export const PanelRelationships = ({
               activeObjectUid: uid,
               existingObjects: relationships,
               objectMetaRelationships,
-              relationshipName: searchObjectsModalState.relationship.name,
+              targetRelationship: searchObjectsModalState.relationship.name,
             });
 
             setModifiedRelationships(

--- a/src/components/panel/panelSections/panelRelationshipsSection.component.tsx
+++ b/src/components/panel/panelSections/panelRelationshipsSection.component.tsx
@@ -38,7 +38,7 @@ interface PanelRelationshipsSectionProps {
     fields?: string[];
   }) => void;
   hasMoreRelationships?: boolean;
-  fetchMoreRelationships: () => void;
+  fetchMoreRelationships?: () => void;
 }
 
 const transition: Transition = {
@@ -70,7 +70,7 @@ const PanelRelationshipSectionComponent = (
 
   useEffect(() => {
     if (inView && hasMoreRelationships) {
-      fetchMoreRelationships();
+      fetchMoreRelationships?.();
     }
   });
 

--- a/src/components/panel/panelSections/panelSectionLayout.component.tsx
+++ b/src/components/panel/panelSections/panelSectionLayout.component.tsx
@@ -41,7 +41,7 @@ export const PanelSectionLayoutComponent = (
 ) => (
   <div
     className={clsx(
-      "mx-auto w-full max-w-7xl flex-grow overflow-y-hidden text-sm ",
+      "mx-auto w-full max-w-7xl flex-grow overflow-y-hidden text-sm",
       isPage && "sm:grid sm:grid-cols-[1fr_3fr]",
     )}
   >

--- a/src/hooks/objects/get/useGetObjectRelationships.ts
+++ b/src/hooks/objects/get/useGetObjectRelationships.ts
@@ -104,7 +104,7 @@ export const useGetObjectRelationships = (
   );
   const variables = { uid, language };
 
-  const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
+  const { data, isLoading, fetchNextPage, isFetchingNextPage } =
     useInfiniteQuery<
       GQLSkylarkGetObjectRelationshipsResponse,
       GQLSkylarkErrorResponse<GQLSkylarkGetObjectResponse>,

--- a/src/hooks/useSkylarkObjectTypes.ts
+++ b/src/hooks/useSkylarkObjectTypes.ts
@@ -24,6 +24,11 @@ import {
   useSkylarkSchemaIntrospection,
 } from "./useSkylarkSchemaIntrospection";
 
+export interface ObjectTypeWithConfig {
+  objectType: string;
+  config: ParsedSkylarkObjectConfig;
+}
+
 export const sortObjectTypesWithConfig = (
   a: {
     objectType: string;
@@ -74,7 +79,7 @@ const useObjectTypesConfig = (objectTypes?: string[]) => {
     gcTime: Infinity,
   });
 
-  const objectTypesWithConfig = useMemo(
+  const objectTypesWithConfig: ObjectTypeWithConfig[] | undefined = useMemo(
     () =>
       objectTypes
         ?.map((objectType) => ({

--- a/src/hooks/useSkylarkSchemaIntrospectionAsDataModelJSON.tsx
+++ b/src/hooks/useSkylarkSchemaIntrospectionAsDataModelJSON.tsx
@@ -13,11 +13,9 @@ import {
 import { formatUriAsCustomerIdentifer, hasProperty } from "src/lib/utils";
 
 import { useSkylarkCreds } from "./localStorage/useCreds";
+import { useAllObjectTypesRelationshipConfiguration } from "./useObjectTypeRelationshipConfiguration";
 import {
-  useAllObjectTypesRelationshipConfiguration,
-  useObjectTypeRelationshipConfiguration,
-} from "./useObjectTypeRelationshipConfiguration";
-import {
+  ObjectTypeWithConfig,
   useAllObjectsMeta,
   useSkylarkObjectTypesWithConfig,
 } from "./useSkylarkObjectTypes";
@@ -322,10 +320,7 @@ const getEnumsForCustomObjects = (
 
 const parseDataModel = (
   allObjectMeta: SkylarkObjectMeta[],
-  objectTypesWithConfig: {
-    objectType: string;
-    config: ParsedSkylarkObjectConfig;
-  }[],
+  objectTypesWithConfig: ObjectTypeWithConfig[],
   accountUri?: string,
   relationshipConfiguration?: Record<
     string,

--- a/src/lib/utils/utils.test.ts
+++ b/src/lib/utils/utils.test.ts
@@ -9,6 +9,7 @@ import {
   createAccountIdentifier,
   getJSONFromLocalStorage,
   getObjectDisplayName,
+  getObjectTypeDisplayNameFromParsedObject,
   getPrimaryKeyField,
   hasProperty,
   isObject,
@@ -141,9 +142,71 @@ describe("getObjectDisplayName", () => {
     expect(got).toEqual("xxx");
   });
 
+  test("falls back to additional config when given", () => {
+    const object = {
+      objectType: "Episode",
+      config: {
+        primaryField: null,
+      },
+      metadata: {
+        uid: "xxx",
+        customField: "custom",
+      },
+    } as unknown as ParsedSkylarkObject;
+    const got = getObjectDisplayName(object, {
+      Episode: { primaryField: "customField" },
+    });
+    expect(got).toEqual("custom");
+  });
+
   test("returns empty string when object is null", () => {
     const got = getObjectDisplayName(null);
     expect(got).toEqual("");
+  });
+});
+
+describe("getObjectTypeDisplayNameFromParsedObject", () => {
+  test("returns empty string when object is null", () => {
+    const got = getObjectTypeDisplayNameFromParsedObject(null);
+
+    expect(got).toBe("");
+  });
+
+  test("returns display name from object config when it exists", () => {
+    const object = {
+      objectType: "SkylarkSet",
+      config: {
+        objectTypeDisplayName: "Set",
+      },
+    } as unknown as ParsedSkylarkObject;
+
+    const got = getObjectTypeDisplayNameFromParsedObject(object);
+
+    expect(got).toBe("Set");
+  });
+
+  test("uses the fallback config when the object doesn't have config", () => {
+    const object = {
+      objectType: "SkylarkSet",
+      config: {},
+    } as unknown as ParsedSkylarkObject;
+
+    const got = getObjectTypeDisplayNameFromParsedObject(object, {
+      SkylarkSet: { objectTypeDisplayName: "CustomDisplayName" },
+    });
+
+    expect(got).toBe("CustomDisplayName");
+  });
+
+  test("defaults to ObjectType when no config is given on the object and no fallback config is given", () => {
+    const object = {
+      objectType: "SkylarkSet",
+      config: {},
+    } as unknown as ParsedSkylarkObject;
+
+    const got = getObjectTypeDisplayNameFromParsedObject(object, {});
+
+    expect(got).toBe("SkylarkSet");
   });
 });
 

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -8,6 +8,7 @@ import {
   BuiltInSkylarkObjectType,
   NormalizedObjectFieldType,
   ParsedSkylarkObject,
+  ParsedSkylarkObjectConfig,
 } from "src/interfaces/skylark";
 
 export const hasProperty = <T, K extends PropertyKey, V = unknown>(
@@ -24,25 +25,37 @@ export const isObject = (input: unknown): input is Record<string, unknown> => {
 export const pause = (ms: number) =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
-export const getPrimaryKeyField = (object: ParsedSkylarkObject) =>
-  [object?.config?.primaryField || "", ...DISPLAY_NAME_PRIORITY].find(
-    (field) => !!object.metadata[field],
-  );
+export const getPrimaryKeyField = (
+  object: ParsedSkylarkObject,
+  fallbackConfig?: Record<string, ParsedSkylarkObjectConfig>,
+) =>
+  [
+    object?.config?.primaryField ||
+      fallbackConfig?.[object.objectType]?.primaryField ||
+      "",
+    ...DISPLAY_NAME_PRIORITY,
+  ].find((field) => !!object.metadata[field]);
 
 export const getObjectDisplayName = (
   object: ParsedSkylarkObject | null,
+  fallbackConfig?: Record<string, ParsedSkylarkObjectConfig>,
 ): string => {
   if (!object) return "";
-  const primaryKeyField = getPrimaryKeyField(object);
+  const primaryKeyField = getPrimaryKeyField(object, fallbackConfig);
   const displayName = primaryKeyField && object.metadata[primaryKeyField];
   return (displayName as string) || object.uid;
 };
 
 export const getObjectTypeDisplayNameFromParsedObject = (
   object: ParsedSkylarkObject | null,
+  fallbackConfig?: Record<string, ParsedSkylarkObjectConfig>,
 ): string => {
   if (!object) return "";
-  return object?.config?.objectTypeDisplayName || object.objectType;
+  return (
+    object?.config?.objectTypeDisplayName ||
+    fallbackConfig?.[object.objectType]?.objectTypeDisplayName ||
+    object.objectType
+  );
 };
 
 // Creates an Account Identifier (used in Flatfile template)


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->
Builds on the ability to make a relationship focussed by using that as the target relationship when dragging.
- If none are active/focussed, work as before (add to multiple)
- If one is active, any that don't match the relationship's object type will show an error
- If two relationships share the same object type, this new method of making one active can be used to target a specific relationship - otherwise it falls back to the previous best guess method.

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Feature

#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://skylarkplatform.atlassian.net/browse/SL-2647
