### PR TITLE
feat: handle permissions when editor API key is used

### DIFF
--- a/src/components/account/status/accountStatus.component.tsx
+++ b/src/components/account/status/accountStatus.component.tsx
@@ -139,11 +139,12 @@ const BackgroundStatusText = ({
 };
 
 export const AccountStatus = () => {
-  const { backgroundTasks, activationStatus } = useAccountStatus(true);
+  const { backgroundTasks, activationStatus, userNeedsSelfConfigPermissions } =
+    useAccountStatus(true);
 
   const [showCompletedText, setShowCompletedText] = useState(false);
 
-  if (activationStatus?.updateInProgress) {
+  if (activationStatus?.updateInProgress && !userNeedsSelfConfigPermissions) {
     if (!showCompletedText) setShowCompletedText(true);
 
     return <StatusText loading>{`Data Model Update In Progress`}</StatusText>;

--- a/src/hooks/useAccountStatus.tsx
+++ b/src/hooks/useAccountStatus.tsx
@@ -12,14 +12,19 @@ import {
 import { skylarkRequest } from "src/lib/graphql/skylark/client";
 import { GET_ACCOUNT_STATUS } from "src/lib/graphql/skylark/queries";
 
-const selectAllData = (data: GQLSkylarkStatusResponse): AccountStatus => ({
-  activationStatus: data.getActivationStatus
+const parseActivationStatus = (
+  getActivationStatus: GQLSkylarkStatusResponse["getActivationStatus"],
+) =>
+  getActivationStatus
     ? {
-        activeVersion: data.getActivationStatus.active_version,
-        updateInProgress: data.getActivationStatus.update_in_progress,
-        updateStartedAt: data.getActivationStatus.update_started_at,
+        activeVersion: getActivationStatus.active_version,
+        updateInProgress: getActivationStatus.update_in_progress,
+        updateStartedAt: getActivationStatus.update_started_at,
       }
-    : null,
+    : null;
+
+const selectAllData = (data: GQLSkylarkStatusResponse): AccountStatus => ({
+  activationStatus: parseActivationStatus(data.getActivationStatus),
   backgroundTasks: {
     queued: data.queuedBackgroundTasks.objects,
     inProgress: data.inProgressBackgroundTasks.objects,
@@ -32,14 +37,7 @@ const selectAllData = (data: GQLSkylarkStatusResponse): AccountStatus => ({
 
 const selectActivationStatus = (
   data: GQLSkylarkStatusResponse,
-): ActivationStatus | null =>
-  data.getActivationStatus
-    ? {
-        activeVersion: data.getActivationStatus.active_version,
-        updateInProgress: data.getActivationStatus.update_in_progress,
-        updateStartedAt: data.getActivationStatus.update_started_at,
-      }
-    : null;
+): ActivationStatus | null => parseActivationStatus(data.getActivationStatus);
 
 function useBackgroundTasksAndActivationStatus<T>(
   select: (data: GQLSkylarkStatusResponse) => T,

--- a/src/interfaces/skylark/environment.ts
+++ b/src/interfaces/skylark/environment.ts
@@ -22,7 +22,7 @@ export interface ActivationStatus {
 }
 
 export interface AccountStatus {
-  activationStatus: ActivationStatus;
+  activationStatus: ActivationStatus | null;
   backgroundTasks: {
     queued: GQLSkylarkBackgroundTask[];
     inProgress: GQLSkylarkBackgroundTask[];

--- a/src/interfaces/skylark/responses.ts
+++ b/src/interfaces/skylark/responses.ts
@@ -40,7 +40,7 @@ export interface GQLSkylarkActivationStatusResponse {
     active_version: number;
     update_in_progress: boolean | null;
     update_started_at: string | null;
-  };
+  } | null;
 }
 
 // https://github.com/skylark-platform/skylark/blob/d5bbe3624eb5341823975d4068f9332c502607b6/components/object-registry/src/tasks/tasks.py#L24C1-L31C62


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->

`getActivationStatus` requires an Admin key. This change makes the useAccountStatus handle getting an error but still having the UI show as connected.

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Bugfix

#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://skylarkplatform.atlassian.net/browse/SL-2939
