### PR TITLE
feat: only call wysiwyg editor onChange when it has initialised

### DIFF
--- a/src/components/wysiwygEditor/wysiwygEditor.component.tsx
+++ b/src/components/wysiwygEditor/wysiwygEditor.component.tsx
@@ -1,5 +1,5 @@
 import { Editor } from "@tinymce/tinymce-react";
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 
 import { Skeleton } from "src/components/skeleton";
 
@@ -58,6 +58,15 @@ export const WYSIWYGEditor = ({
 }: WYSIWYGEditorProps) => {
   const [isLoaded, setIsLoaded] = useState(withSkeletonLoading ? false : true);
 
+  const onEditorChangeWrapper = useCallback(
+    (newValue: string) => {
+      if (onEditorChange && isLoaded) {
+        onEditorChange(newValue);
+      }
+    },
+    [isLoaded, onEditorChange],
+  );
+
   return (
     <div className="relative" data-testid="wysiwyg-editor">
       <Editor
@@ -68,7 +77,7 @@ export const WYSIWYGEditor = ({
         }}
         init={WYSIWYG_INIT}
         value={value}
-        onEditorChange={onEditorChange}
+        onEditorChange={onEditorChangeWrapper}
       />
       {!isLoaded && (
         <div

--- a/src/components/wysiwygEditor/wysiwygEditor.test.tsx
+++ b/src/components/wysiwygEditor/wysiwygEditor.test.tsx
@@ -12,3 +12,11 @@ test("renders the WYSIWYG Editor", async () => {
     "my-editor",
   );
 });
+
+test("doesn't call onEditorChange when the initial value isn't html", async () => {
+  const onEditorChange = jest.fn();
+
+  render(<WYSIWYGEditor onEditorChange={onEditorChange} value="a value" />);
+
+  expect(onEditorChange).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->

This should catch TinyMCE converting non-html strings (`this is a string`) into HTML strings: (`<p>this is a string</p>`) causing users to think they've changed something. Now the conversion will only happen when they actually edit the textbox.

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Bugfix
* [x] Feature

#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://skylarkplatform.atlassian.net/browse/< ticket_id >

